### PR TITLE
Create modern personal homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-# Homepage
+# Private Homepage
+
+Eine moderne One-Pager-Homepage mit adaptivem Design, Suchfunktion und Sicherheits-Basics.
+
+## Features
+
+- Responsives, dunkles & helles Design mit automatischer Anpassung an die Systemeinstellungen
+- Clientseitige Suche, die Abschnitte hervorhebt und Projektkarten filtert
+- Sanfte Micro-Interactions, die sich bei reduzierten Bewegungspräferenzen deaktivieren lassen
+- Barrierearme Navigation inklusive Keyboard- und Screenreader-Optimierung
+
+## Entwicklung
+
+Die Seite ist statisch und benötigt keinen Build-Prozess.
+
+```bash
+# Lokalen Server starten (z. B. mit Python)
+python -m http.server 8000
+```
+
+Danach im Browser `http://localhost:8000` öffnen.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,269 @@
+<!DOCTYPE html>
+<html lang="de">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Private Homepage von Alex – Portfolio, Blog und Kontakt in einem modernen Design." />
+    <title>Alex – Private Homepage</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@300;400;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="site-header" id="top">
+      <nav class="top-nav" aria-label="Hauptnavigation">
+        <a href="#top" class="logo" aria-label="Startseite">Alex<span>.</span></a>
+        <button class="menu-toggle" aria-expanded="false" aria-controls="nav-links">
+          <span class="sr-only">Menü öffnen</span>
+          <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M4 6h16M4 12h16M4 18h16" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+          </svg>
+        </button>
+        <div class="nav-links" id="nav-links">
+          <a href="#about">Über mich</a>
+          <a href="#skills">Skills</a>
+          <a href="#timeline">Timeline</a>
+          <a href="#projects">Projekte</a>
+          <a href="#contact">Kontakt</a>
+        </div>
+        <div class="nav-actions">
+          <input type="search" id="site-search" placeholder="Inhalten suchen…" aria-label="Inhalten suchen" />
+          <button id="theme-toggle" class="icon-button" aria-label="Design wechseln">
+            <svg class="icon-sun" viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M12 4.5V2m0 20v-2.5m7.5-7.5H22M2 12h2.5m14.1-5.6 1.8-1.8M4.6 19.4l1.8-1.8m0-9.2L4.6 6.4m14.8 14.8-1.8-1.8M12 7.5a4.5 4.5 0 1 1 0 9 4.5 4.5 0 0 1 0-9Z" />
+            </svg>
+            <svg class="icon-moon" viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M21 14.5A9 9 0 0 1 9.5 3 7.5 7.5 0 1 0 21 14.5Z" />
+            </svg>
+          </button>
+        </div>
+      </nav>
+      <section class="hero" data-section-title="Hero">
+        <div class="hero-content">
+          <p class="eyebrow">Hallo, ich bin Alex</p>
+          <h1>Ich kreiere digitale Erlebnisse, die Menschen verbinden.</h1>
+          <p>
+            Willkommen auf meiner privaten Homepage. Hier findest du alles rund um meine Projekte, meinen Werdegang und die Themen, die mich antreiben – von Design Thinking über KI bis zu nachhaltiger Technologie.
+          </p>
+          <div class="hero-actions">
+            <a class="button primary" href="#projects">Zu den Projekten</a>
+            <a class="button secondary" href="#contact">Kontakt aufnehmen</a>
+          </div>
+        </div>
+        <div class="hero-visual" aria-hidden="true">
+          <div class="floating-card">
+            <p>Aktuelles Highlight</p>
+            <h2>„Sense &amp; Simplicity“</h2>
+            <p>
+              Eine KI-gestützte Plattform, die komplexe Datenvisualisierung auf jedem Gerät zugänglich macht.
+            </p>
+            <a href="#projects" class="card-link">Mehr erfahren →</a>
+          </div>
+          <div class="orb orb-1"></div>
+          <div class="orb orb-2"></div>
+        </div>
+      </section>
+    </header>
+
+    <main>
+      <section id="about" class="section" data-section-title="Über mich">
+        <div class="section-header">
+          <span class="section-eyebrow">Überblick</span>
+          <h2>Menschenzentrierte Lösungen mit Weitblick</h2>
+        </div>
+        <div class="about-grid">
+          <article class="about-card">
+            <h3>Vision</h3>
+            <p>
+              Ich glaube daran, dass Technologie erst dann wirklich stark ist, wenn sie sich nahtlos in den Alltag einfügt. Daher setze ich auf barrierefreie, sichere und adaptive Interfaces.
+            </p>
+          </article>
+          <article class="about-card">
+            <h3>Fokus</h3>
+            <p>
+              Der Schwerpunkt meiner Arbeit liegt auf modernen Web-Apps, inklusiven User Journeys und nachhaltigen Produktstrategien mit messbarem Impact.
+            </p>
+          </article>
+          <article class="about-card">
+            <h3>Arbeitsweise</h3>
+            <p>
+              Von der Recherche über Rapid Prototyping bis zum Launch begleite ich Projekte iterativ und datengetrieben – transparent, kollaborativ und verlässlich.
+            </p>
+          </article>
+        </div>
+      </section>
+
+      <section id="skills" class="section" data-section-title="Skills">
+        <div class="section-header">
+          <span class="section-eyebrow">Toolset</span>
+          <h2>Skills &amp; Tech Stack</h2>
+          <p>Ein Mix aus Strategie, Design und Code – mit einem Auge fürs Detail.</p>
+        </div>
+        <div class="chips" role="list">
+          <span role="listitem">UX Research</span>
+          <span role="listitem">Design Systeme</span>
+          <span role="listitem">React &amp; TypeScript</span>
+          <span role="listitem">Next.js</span>
+          <span role="listitem">Node.js</span>
+          <span role="listitem">Tailwind &amp; CSS-Architektur</span>
+          <span role="listitem">Barrierefreiheit (WCAG)</span>
+          <span role="listitem">CI/CD Automatisierung</span>
+          <span role="listitem">Datenvisualisierung</span>
+          <span role="listitem">AI-Assisted Workflows</span>
+        </div>
+      </section>
+
+      <section id="timeline" class="section" data-section-title="Timeline">
+        <div class="section-header">
+          <span class="section-eyebrow">Meilensteine</span>
+          <h2>Werdegang</h2>
+        </div>
+        <div class="timeline">
+          <article class="timeline-item">
+            <div class="timeline-year">2025</div>
+            <div class="timeline-content">
+              <h3>Lead Experience Strategist</h3>
+              <p>Aufbau eines interdisziplinären Teams für KI-gestützte Produktentwicklung.</p>
+            </div>
+          </article>
+          <article class="timeline-item">
+            <div class="timeline-year">2023</div>
+            <div class="timeline-content">
+              <h3>Senior Product Designer</h3>
+              <p>Skalierung einer Design-Plattform für mehr als 2 Mio. Nutzer:innen.</p>
+            </div>
+          </article>
+          <article class="timeline-item">
+            <div class="timeline-year">2020</div>
+            <div class="timeline-content">
+              <h3>UX Engineer</h3>
+              <p>Einführung eines komponentenbasierten Systems mit Dark-Mode-Automatisierung.</p>
+            </div>
+          </article>
+          <article class="timeline-item">
+            <div class="timeline-year">2018</div>
+            <div class="timeline-content">
+              <h3>Freelance Designer</h3>
+              <p>Betreuung von Startups bei Brand- und Produktentwicklung.</p>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <section id="projects" class="section" data-section-title="Projekte">
+        <div class="section-header">
+          <span class="section-eyebrow">Showcase</span>
+          <h2>Ausgewählte Projekte</h2>
+          <p>Eine kuratierte Auswahl aktueller Arbeiten und Prototypen.</p>
+        </div>
+        <div class="project-grid">
+          <article class="project-card" data-keywords="ki analyse datenschutz">
+            <div class="project-meta">
+              <span class="project-year">2025</span>
+              <span class="project-type">AI Platform</span>
+            </div>
+            <h3>Sense &amp; Simplicity</h3>
+            <p>Datenschutzfreundliche Analyse-Suite mit explainable AI und adaptivem Interface.</p>
+            <ul>
+              <li>Privacy-by-Design</li>
+              <li>Progressive Web App</li>
+              <li>Design Tokens</li>
+            </ul>
+            <a class="card-link" href="#contact">Projekt anfragen →</a>
+          </article>
+          <article class="project-card" data-keywords="nachhaltigkeit energie dashboard">
+            <div class="project-meta">
+              <span class="project-year">2024</span>
+              <span class="project-type">Dashboard</span>
+            </div>
+            <h3>Green Pulse</h3>
+            <p>Realtime-Energie-Monitoring mit Fokus auf Nachhaltigkeitsziele und Storytelling.</p>
+            <ul>
+              <li>Carbon Analytics</li>
+              <li>Micro-Interactions</li>
+              <li>Accessible Charts</li>
+            </ul>
+            <a class="card-link" href="#contact">Projekt anfragen →</a>
+          </article>
+          <article class="project-card" data-keywords="education community design system">
+            <div class="project-meta">
+              <span class="project-year">2023</span>
+              <span class="project-type">Design System</span>
+            </div>
+            <h3>Learnflow</h3>
+            <p>Community-Plattform mit modularem Design-System und skalierbarer Content-Architektur.</p>
+            <ul>
+              <li>Design Ops</li>
+              <li>Content Strategy</li>
+              <li>Realtime Collaboration</li>
+            </ul>
+            <a class="card-link" href="#contact">Projekt anfragen →</a>
+          </article>
+        </div>
+      </section>
+
+      <section id="contact" class="section" data-section-title="Kontakt">
+        <div class="section-header">
+          <span class="section-eyebrow">Let’s Talk</span>
+          <h2>Bereit für das nächste Kapitel?</h2>
+          <p>Schreib mir, wenn du gemeinsam mit mir innovative Produkte bauen möchtest.</p>
+        </div>
+        <div class="contact-grid">
+          <form class="contact-form" aria-label="Kontaktformular">
+            <div class="form-row">
+              <label for="name">Name</label>
+              <input type="text" id="name" name="name" autocomplete="name" placeholder="Vor- und Nachname" required />
+            </div>
+            <div class="form-row">
+              <label for="email">E-Mail</label>
+              <input type="email" id="email" name="email" autocomplete="email" placeholder="name@example.com" required />
+            </div>
+            <div class="form-row">
+              <label for="message">Nachricht</label>
+              <textarea id="message" name="message" rows="4" placeholder="Erzähl mir von deinem Projekt…" required></textarea>
+            </div>
+            <button type="submit" class="button primary">Nachricht senden</button>
+            <p class="form-hint">Das Formular speichert keine Daten dauerhaft. Du erhältst eine Kopie zur Bestätigung.</p>
+          </form>
+          <aside class="contact-info" aria-label="Kontaktinformationen">
+            <div class="info-card">
+              <h3>Direkter Draht</h3>
+              <p><strong>E-Mail:</strong> <a href="mailto:hello@alex.design">hello@alex.design</a></p>
+              <p><strong>Standort:</strong> Remote-first, Berlin &amp; München</p>
+            </div>
+            <div class="info-card">
+              <h3>Social</h3>
+              <ul>
+                <li><a href="https://www.linkedin.com" target="_blank" rel="noreferrer">LinkedIn</a></li>
+                <li><a href="https://www.github.com" target="_blank" rel="noreferrer">GitHub</a></li>
+                <li><a href="https://www.dribbble.com" target="_blank" rel="noreferrer">Dribbble</a></li>
+              </ul>
+            </div>
+            <div class="info-card">
+              <h3>Newsletter</h3>
+              <p>Monatliche Insights zu Design, KI und Produktstrategie.</p>
+              <button class="button secondary" type="button">Jetzt abonnieren</button>
+            </div>
+          </aside>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <p>© <span id="year"></span> Alex. Alle Rechte vorbehalten.</p>
+      <div class="footer-links">
+        <a href="#top">Nach oben</a>
+        <a href="#">Impressum</a>
+        <a href="#">Datenschutz</a>
+      </div>
+    </footer>
+
+    <div class="search-results" id="search-results" hidden>
+      <p class="results-title">Suchergebnisse</p>
+      <ul id="results-list"></ul>
+    </div>
+
+    <script src="script.js" type="module"></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,235 @@
+const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
+const prefersLight = window.matchMedia('(prefers-color-scheme: light)');
+const root = document.documentElement;
+const body = document.body;
+const themeToggle = document.getElementById('theme-toggle');
+const searchInput = document.getElementById('site-search');
+const menuToggle = document.querySelector('.menu-toggle');
+const navLinks = document.getElementById('nav-links');
+const searchResults = document.getElementById('search-results');
+const resultsList = document.getElementById('results-list');
+const sections = [...document.querySelectorAll('section')];
+
+const STORAGE_KEY = 'alex-theme-preference-v1';
+
+const sectionIndex = sections.map((section) => ({
+  id: section.id,
+  title: section.querySelector('h2')?.textContent ?? section.dataset.sectionTitle,
+  description: section.querySelector('p')?.textContent ?? '',
+}));
+
+function setTheme(theme) {
+  if (theme) {
+    root.setAttribute('data-theme', theme);
+  } else {
+    root.removeAttribute('data-theme');
+  }
+}
+
+function loadStoredTheme() {
+  try {
+    return localStorage.getItem(STORAGE_KEY);
+  } catch (error) {
+    console.warn('Kann gespeicherte Einstellungen nicht lesen.', error);
+    return null;
+  }
+}
+
+function storeTheme(theme) {
+  try {
+    if (theme) {
+      localStorage.setItem(STORAGE_KEY, theme);
+    } else {
+      localStorage.removeItem(STORAGE_KEY);
+    }
+  } catch (error) {
+    console.warn('Kann Einstellungen nicht speichern.', error);
+  }
+}
+
+function resolveInitialTheme() {
+  const stored = loadStoredTheme();
+  if (stored) {
+    setTheme(stored);
+    return;
+  }
+  if (prefersDark.matches) {
+    setTheme('dark');
+  } else if (prefersLight.matches) {
+    setTheme('light');
+  }
+}
+
+function toggleTheme() {
+  const current = root.getAttribute('data-theme');
+  const next = current === 'dark' ? 'light' : 'dark';
+  setTheme(next);
+  storeTheme(next);
+}
+
+themeToggle?.addEventListener('click', toggleTheme);
+
+prefersDark.addEventListener('change', (event) => {
+  if (!loadStoredTheme()) {
+    setTheme(event.matches ? 'dark' : 'light');
+  }
+});
+
+window.addEventListener('DOMContentLoaded', () => {
+  resolveInitialTheme();
+  const year = document.getElementById('year');
+  if (year) {
+    year.textContent = new Date().getFullYear();
+  }
+});
+
+menuToggle?.addEventListener('click', () => {
+  const expanded = menuToggle.getAttribute('aria-expanded') === 'true';
+  menuToggle.setAttribute('aria-expanded', String(!expanded));
+  navLinks?.classList.toggle('open', !expanded);
+});
+
+function searchSections(query) {
+  const normalized = query.trim().toLowerCase();
+  if (!normalized) {
+    searchResults.hidden = true;
+    resultsList.innerHTML = '';
+    removeHighlights();
+    return;
+  }
+
+  const matches = sectionIndex
+    .map((section) => {
+      const text = `${section.title} ${section.description}`.toLowerCase();
+      return text.includes(normalized) ? section : null;
+    })
+    .filter(Boolean);
+
+  resultsList.innerHTML = '';
+  if (!matches.length) {
+    searchResults.hidden = false;
+    const emptyState = document.createElement('li');
+    emptyState.textContent = 'Keine Treffer gefunden.';
+    resultsList.appendChild(emptyState);
+    removeHighlights();
+    return;
+  }
+
+  matches.forEach((match) => {
+    const listItem = document.createElement('li');
+    const link = document.createElement('a');
+    link.href = `#${match.id}`;
+    link.textContent = match.title;
+    link.addEventListener('click', () => {
+      searchResults.hidden = true;
+      removeHighlights();
+      highlightSection(match.id);
+    });
+    const snippet = document.createElement('span');
+    snippet.textContent = match.description;
+    snippet.classList.add('snippet');
+    listItem.appendChild(link);
+    listItem.appendChild(snippet);
+    resultsList.appendChild(listItem);
+  });
+
+  searchResults.hidden = false;
+}
+
+function highlightSection(id) {
+  const section = document.getElementById(id);
+  if (section) {
+    section.classList.add('highlight');
+    section.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    setTimeout(() => {
+      section.classList.remove('highlight');
+    }, 2400);
+  }
+}
+
+function removeHighlights() {
+  sections.forEach((section) => section.classList.remove('highlight'));
+}
+
+searchInput?.addEventListener('input', (event) => {
+  const value = event.target.value;
+  searchSections(value);
+});
+
+searchInput?.addEventListener('focus', () => {
+  if (searchInput.value) {
+    searchSections(searchInput.value);
+  }
+});
+
+window.addEventListener('click', (event) => {
+  if (!searchResults.contains(event.target) && event.target !== searchInput) {
+    searchResults.hidden = true;
+  }
+});
+
+// Motion preference: disable animations when user prefers reduced motion
+const mediaMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
+if (mediaMotion.matches) {
+  disableAnimations();
+}
+mediaMotion.addEventListener('change', (event) => {
+  if (event.matches) {
+    disableAnimations();
+  } else {
+    enableAnimations();
+  }
+});
+
+let originalTransitions = [];
+
+function disableAnimations() {
+  originalTransitions = [];
+  document.querySelectorAll('*').forEach((element) => {
+    const transition = getComputedStyle(element).transition;
+    const animation = getComputedStyle(element).animation;
+    originalTransitions.push({ element, transition, animation });
+    element.style.transition = 'none';
+    element.style.animation = 'none';
+  });
+}
+
+function enableAnimations() {
+  originalTransitions.forEach(({ element, transition, animation }) => {
+    element.style.transition = transition;
+    element.style.animation = animation;
+  });
+  originalTransitions = [];
+}
+
+// Enhance project cards with keyword search
+const projectCards = [...document.querySelectorAll('.project-card')];
+
+function searchProjects(query) {
+  const normalized = query.trim().toLowerCase();
+  if (!normalized) {
+    projectCards.forEach((card) => (card.hidden = false));
+    return;
+  }
+
+  projectCards.forEach((card) => {
+    const keywords = card.dataset.keywords ?? '';
+    const text = `${card.textContent} ${keywords}`.toLowerCase();
+    card.hidden = !text.includes(normalized);
+  });
+}
+
+searchInput?.addEventListener('input', (event) => {
+  const value = event.target.value;
+  searchProjects(value);
+});
+
+// Close search results with Escape key
+searchInput?.addEventListener('keydown', (event) => {
+  if (event.key === 'Escape') {
+    searchInput.value = '';
+    searchResults.hidden = true;
+    removeHighlights();
+    searchProjects('');
+  }
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,790 @@
+:root {
+  color-scheme: light dark;
+  --font-family: 'Manrope', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --transition-base: 200ms ease;
+  --radius-lg: 24px;
+  --radius-md: 18px;
+  --radius-sm: 12px;
+  --shadow-soft: 0 20px 45px -20px rgba(15, 23, 42, 0.35);
+  --shadow-hard: 0 24px 60px -20px rgba(15, 23, 42, 0.55);
+  --max-width: 1180px;
+  --gradient: linear-gradient(135deg, var(--accent-500), var(--accent-300));
+  --accent-300: #7f5dff;
+  --accent-400: #6b4cff;
+  --accent-500: #4f37ff;
+  --surface-50: rgba(255, 255, 255, 0.9);
+  --surface-100: rgba(255, 255, 255, 0.75);
+  --surface-900: rgba(17, 24, 39, 0.75);
+  --neutral-50: #f8fafc;
+  --neutral-100: #eef2ff;
+  --neutral-900: #0f172a;
+  --text-primary: #0f172a;
+  --text-secondary: #1e293b;
+  --text-tertiary: rgba(15, 23, 42, 0.65);
+  --border-color: rgba(148, 163, 184, 0.2);
+  --backdrop: rgba(15, 23, 42, 0.07);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --accent-300: #9e86ff;
+    --accent-400: #836bff;
+    --accent-500: #5b4bff;
+    --surface-50: rgba(15, 23, 42, 0.8);
+    --surface-100: rgba(15, 23, 42, 0.6);
+    --surface-900: rgba(2, 6, 23, 0.85);
+    --neutral-50: #0b1120;
+    --neutral-100: #111827;
+    --neutral-900: #e2e8f0;
+    --text-primary: #e2e8f0;
+    --text-secondary: #cbd5f5;
+    --text-tertiary: rgba(226, 232, 240, 0.65);
+    --border-color: rgba(148, 163, 184, 0.25);
+    --backdrop: rgba(15, 23, 42, 0.35);
+  }
+}
+
+[data-theme='dark'] {
+  --accent-300: #9e86ff;
+  --accent-400: #836bff;
+  --accent-500: #5b4bff;
+  --surface-50: rgba(15, 23, 42, 0.8);
+  --surface-100: rgba(15, 23, 42, 0.6);
+  --surface-900: rgba(2, 6, 23, 0.85);
+  --neutral-50: #0b1120;
+  --neutral-100: #111827;
+  --neutral-900: #e2e8f0;
+  --text-primary: #e2e8f0;
+  --text-secondary: #cbd5f5;
+  --text-tertiary: rgba(226, 232, 240, 0.65);
+  --border-color: rgba(148, 163, 184, 0.25);
+  --backdrop: rgba(15, 23, 42, 0.35);
+}
+
+[data-theme='light'] {
+  --accent-300: #7f5dff;
+  --accent-400: #6b4cff;
+  --accent-500: #4f37ff;
+  --surface-50: rgba(255, 255, 255, 0.9);
+  --surface-100: rgba(255, 255, 255, 0.75);
+  --surface-900: rgba(17, 24, 39, 0.75);
+  --neutral-50: #f8fafc;
+  --neutral-100: #eef2ff;
+  --neutral-900: #0f172a;
+  --text-primary: #0f172a;
+  --text-secondary: #1e293b;
+  --text-tertiary: rgba(15, 23, 42, 0.65);
+  --border-color: rgba(148, 163, 184, 0.2);
+  --backdrop: rgba(15, 23, 42, 0.07);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-family);
+  background: radial-gradient(circle at top left, rgba(79, 55, 255, 0.22), transparent 55%),
+    radial-gradient(circle at bottom right, rgba(125, 106, 255, 0.18), transparent 50%), var(--neutral-50);
+  color: var(--text-primary);
+  min-height: 100vh;
+  padding-bottom: 4rem;
+  transition: background 400ms ease, color 200ms ease;
+}
+
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(79, 55, 255, 0.08), transparent 60%);
+  pointer-events: none;
+  z-index: -1;
+}
+
+[data-theme='dark'] body,
+@media (prefers-color-scheme: dark) {
+  body {
+    background: radial-gradient(circle at top left, rgba(79, 55, 255, 0.32), transparent 55%),
+      radial-gradient(circle at bottom right, rgba(125, 106, 255, 0.28), transparent 50%), var(--neutral-50);
+  }
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  color: var(--accent-400);
+}
+
+img {
+  max-width: 100%;
+  height: auto;
+  display: block;
+}
+
+.section {
+  padding: 96px 24px;
+  position: relative;
+}
+
+.section::before {
+  content: attr(data-section-title);
+  position: absolute;
+  top: 32px;
+  right: 24px;
+  font-size: 0.75rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+  opacity: 0.45;
+}
+
+.section-header {
+  max-width: 720px;
+  margin: 0 auto 48px;
+  text-align: center;
+}
+
+.section-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 6px 14px;
+  border-radius: 999px;
+  background: rgba(79, 55, 255, 0.1);
+  color: var(--accent-500);
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.section-header h2 {
+  font-size: clamp(2rem, 4vw, 3rem);
+  margin: 20px 0 16px;
+}
+
+.section-header p {
+  color: var(--text-tertiary);
+  margin: 0 auto;
+  max-width: 580px;
+}
+
+.site-header {
+  position: relative;
+  padding: 24px;
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.6), rgba(255, 255, 255, 0));
+  backdrop-filter: blur(18px);
+}
+
+.top-nav {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 20px;
+  align-items: center;
+}
+
+.logo {
+  font-size: 1.5rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+.logo span {
+  color: var(--accent-400);
+}
+
+.nav-links {
+  display: flex;
+  gap: 1.5rem;
+  justify-content: center;
+  align-items: center;
+}
+
+.nav-links a {
+  font-weight: 500;
+  color: var(--text-secondary);
+}
+
+.nav-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+#site-search {
+  width: 220px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  padding: 10px 14px;
+  background: rgba(255, 255, 255, 0.65);
+  color: inherit;
+  backdrop-filter: blur(10px);
+  transition: border-color var(--transition-base), box-shadow var(--transition-base);
+}
+
+[data-theme='dark'] #site-search,
+@media (prefers-color-scheme: dark) {
+  #site-search {
+    background: rgba(15, 23, 42, 0.55);
+  }
+}
+
+#site-search:focus {
+  outline: none;
+  border-color: var(--accent-400);
+  box-shadow: 0 0 0 4px rgba(79, 55, 255, 0.15);
+}
+
+.icon-button {
+  border: none;
+  background: rgba(79, 55, 255, 0.1);
+  color: var(--accent-500);
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  transition: transform var(--transition-base), background var(--transition-base);
+}
+
+.icon-button:hover {
+  transform: translateY(-1px);
+  background: rgba(79, 55, 255, 0.18);
+}
+
+.icon-button svg {
+  width: 24px;
+  height: 24px;
+  fill: currentColor;
+}
+
+.icon-moon {
+  display: none;
+}
+
+[data-theme='dark'] .icon-sun,
+@media (prefers-color-scheme: dark) {
+  .icon-sun {
+    display: none;
+  }
+}
+
+[data-theme='dark'] .icon-moon,
+@media (prefers-color-scheme: dark) {
+  .icon-moon {
+    display: block;
+  }
+}
+
+.hero {
+  max-width: var(--max-width);
+  margin: 64px auto 0;
+  display: grid;
+  gap: 48px;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  align-items: center;
+}
+
+.hero-content h1 {
+  font-size: clamp(2.8rem, 6vw, 4.2rem);
+  line-height: 1.05;
+  letter-spacing: -0.04em;
+  margin-bottom: 24px;
+}
+
+.hero-content p {
+  color: var(--text-tertiary);
+  font-size: 1.1rem;
+  line-height: 1.7;
+}
+
+.hero-actions {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+  margin-top: 32px;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 12px 22px;
+  border-radius: var(--radius-md);
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  border: none;
+  transition: transform var(--transition-base), box-shadow var(--transition-base), background var(--transition-base);
+}
+
+.button.primary {
+  background: var(--gradient);
+  color: white;
+  box-shadow: var(--shadow-soft);
+}
+
+.button.primary:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-hard);
+}
+
+.button.secondary {
+  background: rgba(79, 55, 255, 0.1);
+  color: var(--accent-500);
+}
+
+.button.secondary:hover {
+  background: rgba(79, 55, 255, 0.18);
+}
+
+.hero-visual {
+  position: relative;
+  display: grid;
+  place-items: center;
+}
+
+.floating-card {
+  position: relative;
+  padding: 32px;
+  border-radius: var(--radius-lg);
+  background: var(--surface-50);
+  color: inherit;
+  box-shadow: var(--shadow-soft);
+  max-width: 360px;
+  backdrop-filter: blur(16px);
+  border: 1px solid var(--border-color);
+}
+
+.floating-card p:first-child {
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.75rem;
+  color: var(--text-tertiary);
+}
+
+.floating-card h2 {
+  margin: 12px 0;
+  font-size: 1.6rem;
+}
+
+.card-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-weight: 600;
+  color: var(--accent-500);
+}
+
+.orb {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(0);
+  opacity: 0.7;
+}
+
+.orb-1 {
+  width: 220px;
+  height: 220px;
+  background: radial-gradient(circle, rgba(79, 55, 255, 0.35), transparent 70%);
+  top: -60px;
+  right: -40px;
+}
+
+.orb-2 {
+  width: 300px;
+  height: 300px;
+  background: radial-gradient(circle, rgba(125, 106, 255, 0.25), transparent 70%);
+  bottom: -80px;
+  left: -80px;
+}
+
+.about-grid {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.about-card {
+  padding: 32px;
+  border-radius: var(--radius-lg);
+  background: var(--surface-50);
+  border: 1px solid var(--border-color);
+  backdrop-filter: blur(16px);
+  box-shadow: var(--shadow-soft);
+  transition: transform var(--transition-base), border-color var(--transition-base);
+}
+
+.about-card:hover {
+  transform: translateY(-4px);
+  border-color: rgba(79, 55, 255, 0.35);
+}
+
+.about-card h3 {
+  margin-top: 0;
+  margin-bottom: 12px;
+}
+
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  justify-content: center;
+}
+
+.chips span {
+  padding: 10px 18px;
+  border-radius: 999px;
+  border: 1px solid rgba(79, 55, 255, 0.15);
+  background: rgba(79, 55, 255, 0.08);
+  color: var(--accent-500);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.timeline {
+  display: grid;
+  gap: 24px;
+  max-width: 680px;
+  margin: 0 auto;
+}
+
+.timeline-item {
+  display: grid;
+  grid-template-columns: 120px 1fr;
+  gap: 24px;
+  padding: 24px;
+  border-radius: var(--radius-md);
+  background: var(--surface-50);
+  border: 1px solid var(--border-color);
+  position: relative;
+  overflow: hidden;
+}
+
+.timeline-item::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(135deg, rgba(79, 55, 255, 0.12), transparent 60%);
+  opacity: 0;
+  transition: opacity var(--transition-base);
+}
+
+.timeline-item:hover::after {
+  opacity: 1;
+}
+
+.timeline-year {
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: var(--accent-500);
+}
+
+.project-grid {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.project-card {
+  padding: 28px;
+  border-radius: var(--radius-lg);
+  background: var(--surface-50);
+  border: 1px solid var(--border-color);
+  backdrop-filter: blur(18px);
+  display: grid;
+  gap: 16px;
+  transition: transform var(--transition-base), border-color var(--transition-base);
+}
+
+.project-card:hover {
+  transform: translateY(-6px);
+  border-color: rgba(79, 55, 255, 0.35);
+}
+
+.project-meta {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.9rem;
+  color: var(--text-tertiary);
+}
+
+.project-card ul {
+  margin: 0;
+  padding-left: 18px;
+  color: var(--text-tertiary);
+}
+
+.contact-grid {
+  display: grid;
+  gap: 32px;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  align-items: start;
+}
+
+.contact-form {
+  padding: 36px;
+  border-radius: var(--radius-lg);
+  background: var(--surface-50);
+  border: 1px solid var(--border-color);
+  backdrop-filter: blur(16px);
+  box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: 20px;
+}
+
+.form-row {
+  display: grid;
+  gap: 8px;
+}
+
+label {
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+input,
+textarea {
+  width: 100%;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  padding: 12px 16px;
+  background: rgba(255, 255, 255, 0.7);
+  color: inherit;
+  font-family: inherit;
+  transition: border-color var(--transition-base), box-shadow var(--transition-base);
+}
+
+[data-theme='dark'] input,
+[data-theme='dark'] textarea,
+@media (prefers-color-scheme: dark) {
+  input,
+  textarea {
+    background: rgba(15, 23, 42, 0.55);
+  }
+}
+
+input:focus,
+textarea:focus {
+  outline: none;
+  border-color: var(--accent-400);
+  box-shadow: 0 0 0 4px rgba(79, 55, 255, 0.15);
+}
+
+.form-hint {
+  font-size: 0.85rem;
+  color: var(--text-tertiary);
+  margin-top: -8px;
+}
+
+.contact-info {
+  display: grid;
+  gap: 20px;
+}
+
+.info-card {
+  padding: 24px;
+  border-radius: var(--radius-lg);
+  background: var(--surface-50);
+  border: 1px solid var(--border-color);
+  backdrop-filter: blur(14px);
+  display: grid;
+  gap: 10px;
+}
+
+.site-footer {
+  border-top: 1px solid var(--border-color);
+  padding: 48px 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  color: var(--text-tertiary);
+}
+
+.footer-links {
+  display: flex;
+  gap: 18px;
+  flex-wrap: wrap;
+}
+
+.search-results {
+  position: fixed;
+  top: 80px;
+  right: 24px;
+  width: min(360px, 90vw);
+  max-height: 70vh;
+  overflow-y: auto;
+  background: var(--surface-50);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border-color);
+  box-shadow: var(--shadow-hard);
+  backdrop-filter: blur(18px);
+  padding: 24px;
+  display: grid;
+  gap: 16px;
+  z-index: 10;
+}
+
+.results-title {
+  margin: 0;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  font-size: 0.85rem;
+  color: var(--text-tertiary);
+}
+
+#results-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 12px;
+}
+
+#results-list li {
+  display: grid;
+  gap: 4px;
+}
+
+#results-list a {
+  font-weight: 600;
+  color: var(--accent-500);
+}
+
+.snippet {
+  font-size: 0.85rem;
+  color: var(--text-tertiary);
+}
+
+.highlight {
+  outline: 2px solid var(--accent-400);
+  outline-offset: 6px;
+  border-radius: var(--radius-lg);
+  transition: outline var(--transition-base);
+}
+
+.menu-toggle {
+  display: none;
+  border: none;
+  background: rgba(79, 55, 255, 0.1);
+  color: var(--accent-500);
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.menu-toggle svg {
+  width: 28px;
+  height: 28px;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+@media (max-width: 960px) {
+  .top-nav {
+    grid-template-columns: auto auto;
+    grid-template-areas:
+      'logo actions'
+      'menu menu';
+    justify-content: space-between;
+  }
+
+  .logo {
+    grid-area: logo;
+  }
+
+  .nav-actions {
+    grid-area: actions;
+    justify-content: flex-end;
+  }
+
+  .menu-toggle {
+    display: inline-flex;
+  }
+
+  .nav-links {
+    grid-area: menu;
+    display: none;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+    padding: 16px;
+    border-radius: var(--radius-lg);
+    background: var(--surface-50);
+    border: 1px solid var(--border-color);
+    backdrop-filter: blur(16px);
+    animation: fadeIn 180ms ease;
+  }
+
+  .nav-links.open {
+    display: flex;
+  }
+
+  #site-search {
+    width: 180px;
+  }
+}
+
+@media (max-width: 720px) {
+  .section {
+    padding: 72px 20px;
+  }
+
+  .hero {
+    margin-top: 32px;
+  }
+
+  .hero-content h1 {
+    font-size: clamp(2.4rem, 8vw, 3.4rem);
+  }
+
+  .floating-card {
+    max-width: 320px;
+  }
+
+  .timeline-item {
+    grid-template-columns: 1fr;
+  }
+
+  .timeline-year {
+    order: 2;
+  }
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}


### PR DESCRIPTION
## Summary
- add a single-page personal site with hero, timeline, projects, and contact sections
- implement responsive styling with automatic dark/light theme detection and manual toggle
- build client-side search that highlights sections and filters projects, plus documentation for local preview

## Testing
- No automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e1b63a66b083258009af249121fca0