### PR TITLE
Refresh Adrian homepage with legal pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,37 @@
-# Homepage
+# Adrian Dylan-Wulff – Private Homepage
+
+Persönliche, moderne Homepage mit adaptivem Design, Suchfunktion und sanften Micro-Interactions.
+
+## Features
+
+- Responsives, dunkles & helles Design mit automatischer Anpassung an die Systemeinstellungen
+- Clientseitige Suche, die Abschnitte hervorhebt und Karten in Projekte-, Journal- und Lieblings-Bereichen filtert
+- Persönlicher Journal-Bereich samt Highlights und Favoriten-Galerie
+- Sanfte Micro-Interactions, die sich bei reduzierten Bewegungspräferenzen deaktivieren lassen
+- Barrierearme Navigation inklusive Keyboard- und Screenreader-Optimierung
+
+## Struktur
+
+- `index.html` – zentrale Startseite mit persönlichen Abschnitten
+- `impressum.html`, `datenschutz.html` – rechtliche Einzelseiten im selben Design
+- `assets/css/styles.css` – globales Stylesheet
+- `assets/js/main.js` – Interaktionen (Theme, Suche, Filter, Motion Preferences)
+- `assets/meta/` – Platz für zusätzliche Metadaten (z. B. `manifest.webmanifest` bei Bedarf)
+- `sitemap.xml` – Sitemap für bessere Auffindbarkeit in Suchmaschinen
+
+## Entwicklung
+
+Die Seite ist statisch und benötigt keinen Build-Prozess.
+
+```bash
+# Lokalen Server starten (z. B. mit Python)
+python -m http.server 8000
+```
+
+Danach im Browser `http://localhost:8000` öffnen.
+
+## Hinweise
+
+- Um Inhalte anzupassen, bearbeite einfach die HTML-Abschnitte oder ergänze neue Karten.
+- Die Suchfunktion basiert auf Textinhalten der Sektionen – relevante Stichwörter können über `data-keywords` hinterlegt werden.
+- Für zusätzliche Assets wie Bilder empfiehlt sich der Ordner `assets/` (z. B. `assets/images/`).

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,0 +1,892 @@
+:root {
+  color-scheme: light dark;
+  --font-family: 'Manrope', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --transition-base: 200ms ease;
+  --radius-lg: 24px;
+  --radius-md: 18px;
+  --radius-sm: 12px;
+  --shadow-soft: 0 20px 45px -20px rgba(15, 23, 42, 0.35);
+  --shadow-hard: 0 24px 60px -20px rgba(15, 23, 42, 0.55);
+  --max-width: 1180px;
+  --gradient: linear-gradient(135deg, var(--accent-500), var(--accent-300));
+  --accent-300: #7f5dff;
+  --accent-400: #6b4cff;
+  --accent-500: #4f37ff;
+  --surface-50: rgba(255, 255, 255, 0.9);
+  --surface-100: rgba(255, 255, 255, 0.75);
+  --surface-900: rgba(17, 24, 39, 0.75);
+  --neutral-50: #f8fafc;
+  --neutral-100: #eef2ff;
+  --neutral-900: #0f172a;
+  --text-primary: #0f172a;
+  --text-secondary: #1e293b;
+  --text-tertiary: rgba(15, 23, 42, 0.65);
+  --border-color: rgba(148, 163, 184, 0.2);
+  --backdrop: rgba(15, 23, 42, 0.07);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --accent-300: #9e86ff;
+    --accent-400: #836bff;
+    --accent-500: #5b4bff;
+    --surface-50: rgba(15, 23, 42, 0.8);
+    --surface-100: rgba(15, 23, 42, 0.6);
+    --surface-900: rgba(2, 6, 23, 0.85);
+    --neutral-50: #0b1120;
+    --neutral-100: #111827;
+    --neutral-900: #e2e8f0;
+    --text-primary: #e2e8f0;
+    --text-secondary: #cbd5f5;
+    --text-tertiary: rgba(226, 232, 240, 0.65);
+    --border-color: rgba(148, 163, 184, 0.25);
+    --backdrop: rgba(15, 23, 42, 0.35);
+  }
+}
+
+[data-theme='dark'] {
+  --accent-300: #9e86ff;
+  --accent-400: #836bff;
+  --accent-500: #5b4bff;
+  --surface-50: rgba(15, 23, 42, 0.8);
+  --surface-100: rgba(15, 23, 42, 0.6);
+  --surface-900: rgba(2, 6, 23, 0.85);
+  --neutral-50: #0b1120;
+  --neutral-100: #111827;
+  --neutral-900: #e2e8f0;
+  --text-primary: #e2e8f0;
+  --text-secondary: #cbd5f5;
+  --text-tertiary: rgba(226, 232, 240, 0.65);
+  --border-color: rgba(148, 163, 184, 0.25);
+  --backdrop: rgba(15, 23, 42, 0.35);
+}
+
+[data-theme='light'] {
+  --accent-300: #7f5dff;
+  --accent-400: #6b4cff;
+  --accent-500: #4f37ff;
+  --surface-50: rgba(255, 255, 255, 0.9);
+  --surface-100: rgba(255, 255, 255, 0.75);
+  --surface-900: rgba(17, 24, 39, 0.75);
+  --neutral-50: #f8fafc;
+  --neutral-100: #eef2ff;
+  --neutral-900: #0f172a;
+  --text-primary: #0f172a;
+  --text-secondary: #1e293b;
+  --text-tertiary: rgba(15, 23, 42, 0.65);
+  --border-color: rgba(148, 163, 184, 0.2);
+  --backdrop: rgba(15, 23, 42, 0.07);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-family);
+  background: radial-gradient(circle at top left, rgba(79, 55, 255, 0.22), transparent 55%),
+    radial-gradient(circle at bottom right, rgba(125, 106, 255, 0.18), transparent 50%), var(--neutral-50);
+  color: var(--text-primary);
+  min-height: 100vh;
+  padding-bottom: 4rem;
+  transition: background 400ms ease, color 200ms ease;
+}
+
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(79, 55, 255, 0.08), transparent 60%);
+  pointer-events: none;
+  z-index: -1;
+}
+
+[data-theme='dark'] body,
+@media (prefers-color-scheme: dark) {
+  body {
+    background: radial-gradient(circle at top left, rgba(79, 55, 255, 0.32), transparent 55%),
+      radial-gradient(circle at bottom right, rgba(125, 106, 255, 0.28), transparent 50%), var(--neutral-50);
+  }
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  color: var(--accent-400);
+}
+
+img {
+  max-width: 100%;
+  height: auto;
+  display: block;
+}
+
+.section {
+  padding: 96px 24px;
+  position: relative;
+}
+
+.section::before {
+  content: attr(data-section-title);
+  position: absolute;
+  top: 32px;
+  right: 24px;
+  font-size: 0.75rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+  opacity: 0.45;
+}
+
+.section-header {
+  max-width: 720px;
+  margin: 0 auto 48px;
+  text-align: center;
+}
+
+.section-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 6px 14px;
+  border-radius: 999px;
+  background: rgba(79, 55, 255, 0.1);
+  color: var(--accent-500);
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.section-header h2 {
+  font-size: clamp(2rem, 4vw, 3rem);
+  margin: 20px 0 16px;
+}
+
+.section-header p {
+  color: var(--text-tertiary);
+  margin: 0 auto;
+  max-width: 580px;
+}
+
+.site-header {
+  position: relative;
+  padding: 24px;
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.6), rgba(255, 255, 255, 0));
+  backdrop-filter: blur(18px);
+}
+
+.top-nav {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 20px;
+  align-items: center;
+}
+
+.logo {
+  font-size: 1.5rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+.logo span {
+  color: var(--accent-400);
+}
+
+.nav-links {
+  display: flex;
+  gap: 1.5rem;
+  justify-content: center;
+  align-items: center;
+}
+
+.nav-links a {
+  font-weight: 500;
+  color: var(--text-secondary);
+}
+
+.nav-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+#site-search {
+  width: 220px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  padding: 10px 14px;
+  background: rgba(255, 255, 255, 0.65);
+  color: inherit;
+  backdrop-filter: blur(10px);
+  transition: border-color var(--transition-base), box-shadow var(--transition-base);
+}
+
+[data-theme='dark'] #site-search,
+@media (prefers-color-scheme: dark) {
+  #site-search {
+    background: rgba(15, 23, 42, 0.55);
+  }
+}
+
+#site-search:focus {
+  outline: none;
+  border-color: var(--accent-400);
+  box-shadow: 0 0 0 4px rgba(79, 55, 255, 0.15);
+}
+
+.icon-button {
+  border: none;
+  background: rgba(79, 55, 255, 0.1);
+  color: var(--accent-500);
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  transition: transform var(--transition-base), background var(--transition-base);
+}
+
+.icon-button:hover {
+  transform: translateY(-1px);
+  background: rgba(79, 55, 255, 0.18);
+}
+
+.icon-button svg {
+  width: 24px;
+  height: 24px;
+  fill: currentColor;
+}
+
+.icon-moon {
+  display: none;
+}
+
+[data-theme='dark'] .icon-sun,
+@media (prefers-color-scheme: dark) {
+  .icon-sun {
+    display: none;
+  }
+}
+
+[data-theme='dark'] .icon-moon,
+@media (prefers-color-scheme: dark) {
+  .icon-moon {
+    display: block;
+  }
+}
+
+.hero {
+  max-width: var(--max-width);
+  margin: 64px auto 0;
+  display: grid;
+  gap: 48px;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  align-items: center;
+}
+
+.hero-content h1 {
+  font-size: clamp(2.8rem, 6vw, 4.2rem);
+  line-height: 1.05;
+  letter-spacing: -0.04em;
+  margin-bottom: 24px;
+}
+
+.hero-content p {
+  color: var(--text-tertiary);
+  font-size: 1.1rem;
+  line-height: 1.7;
+}
+
+.hero-actions {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+  margin-top: 32px;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 12px 22px;
+  border-radius: var(--radius-md);
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  border: none;
+  transition: transform var(--transition-base), box-shadow var(--transition-base), background var(--transition-base);
+}
+
+.button.primary {
+  background: var(--gradient);
+  color: white;
+  box-shadow: var(--shadow-soft);
+}
+
+.button.primary:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-hard);
+}
+
+.button.secondary {
+  background: rgba(79, 55, 255, 0.1);
+  color: var(--accent-500);
+}
+
+.button.secondary:hover {
+  background: rgba(79, 55, 255, 0.18);
+}
+
+.hero-visual {
+  position: relative;
+  display: grid;
+  place-items: center;
+}
+
+.legal-hero {
+  padding-block: 120px 60px;
+  min-height: auto;
+}
+
+.legal-hero .hero-content {
+  text-align: center;
+}
+
+.floating-card {
+  position: relative;
+  padding: 32px;
+  border-radius: var(--radius-lg);
+  background: var(--surface-50);
+  color: inherit;
+  box-shadow: var(--shadow-soft);
+  max-width: 360px;
+  backdrop-filter: blur(16px);
+  border: 1px solid var(--border-color);
+}
+
+.floating-card p:first-child {
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.75rem;
+  color: var(--text-tertiary);
+}
+
+.floating-card h2 {
+  margin: 12px 0;
+  font-size: 1.6rem;
+}
+
+.card-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-weight: 600;
+  color: var(--accent-500);
+}
+
+.orb {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(0);
+  opacity: 0.7;
+}
+
+.orb-1 {
+  width: 220px;
+  height: 220px;
+  background: radial-gradient(circle, rgba(79, 55, 255, 0.35), transparent 70%);
+  top: -60px;
+  right: -40px;
+}
+
+.orb-2 {
+  width: 300px;
+  height: 300px;
+  background: radial-gradient(circle, rgba(125, 106, 255, 0.25), transparent 70%);
+  bottom: -80px;
+  left: -80px;
+}
+
+.about-grid {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.about-card {
+  padding: 32px;
+  border-radius: var(--radius-lg);
+  background: var(--surface-50);
+  border: 1px solid var(--border-color);
+  backdrop-filter: blur(16px);
+  box-shadow: var(--shadow-soft);
+  transition: transform var(--transition-base), border-color var(--transition-base);
+}
+
+.about-card:hover {
+  transform: translateY(-4px);
+  border-color: rgba(79, 55, 255, 0.35);
+}
+
+.about-card h3 {
+  margin-top: 0;
+  margin-bottom: 12px;
+}
+
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  justify-content: center;
+}
+
+.chips span {
+  padding: 10px 18px;
+  border-radius: 999px;
+  border: 1px solid rgba(79, 55, 255, 0.15);
+  background: rgba(79, 55, 255, 0.08);
+  color: var(--accent-500);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.timeline {
+  display: grid;
+  gap: 24px;
+  max-width: 680px;
+  margin: 0 auto;
+}
+
+.timeline-item {
+  display: grid;
+  grid-template-columns: 120px 1fr;
+  gap: 24px;
+  padding: 24px;
+  border-radius: var(--radius-md);
+  background: var(--surface-50);
+  border: 1px solid var(--border-color);
+  position: relative;
+  overflow: hidden;
+}
+
+.timeline-item::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(135deg, rgba(79, 55, 255, 0.12), transparent 60%);
+  opacity: 0;
+  transition: opacity var(--transition-base);
+}
+
+.timeline-item:hover::after {
+  opacity: 1;
+}
+
+.timeline-year {
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: var(--accent-500);
+}
+
+.project-grid {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.project-card {
+  padding: 28px;
+  border-radius: var(--radius-lg);
+  background: var(--surface-50);
+  border: 1px solid var(--border-color);
+  backdrop-filter: blur(18px);
+  display: grid;
+  gap: 16px;
+  transition: transform var(--transition-base), border-color var(--transition-base);
+}
+
+.project-card:hover {
+  transform: translateY(-6px);
+  border-color: rgba(79, 55, 255, 0.35);
+}
+
+.project-meta {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.9rem;
+  color: var(--text-tertiary);
+}
+
+.project-card ul {
+  margin: 0;
+  padding-left: 18px;
+  color: var(--text-tertiary);
+}
+
+.journal-grid {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.journal-card {
+  padding: 26px;
+  border-radius: var(--radius-lg);
+  background: var(--surface-50);
+  border: 1px solid var(--border-color);
+  display: grid;
+  gap: 14px;
+  position: relative;
+  overflow: hidden;
+  transition: transform var(--transition-base), border-color var(--transition-base);
+}
+
+.journal-card::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(135deg, rgba(255, 94, 0, 0.12), transparent 60%);
+  opacity: 0;
+  transition: opacity var(--transition-base);
+  pointer-events: none;
+}
+
+.journal-card:hover {
+  transform: translateY(-4px);
+  border-color: rgba(255, 94, 0, 0.35);
+}
+
+.journal-card:hover::after {
+  opacity: 1;
+}
+
+.journal-card time {
+  font-size: 0.85rem;
+  color: var(--text-tertiary);
+}
+
+.favorites-grid {
+  display: grid;
+  gap: 20px;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.favorite-card {
+  padding: 24px;
+  border-radius: var(--radius-lg);
+  background: var(--surface-50);
+  border: 1px dashed var(--border-color);
+  box-shadow: var(--shadow-soft);
+  transition: border-color var(--transition-base), background var(--transition-base);
+}
+
+.favorite-card h3 {
+  margin-bottom: 10px;
+  color: var(--accent-500);
+  font-size: 1.05rem;
+}
+
+.favorite-card:hover {
+  border-color: rgba(79, 55, 255, 0.35);
+  background: rgba(79, 55, 255, 0.08);
+}
+
+.legal-content {
+  max-width: 760px;
+  margin: 0 auto;
+  display: grid;
+  gap: 24px;
+  text-align: left;
+}
+
+.legal-content h2 {
+  font-size: 1.4rem;
+  margin-top: 12px;
+}
+
+.legal-content p,
+.legal-content li {
+  color: var(--text-secondary);
+  line-height: 1.7;
+}
+
+.legal-content a {
+  color: var(--accent-500);
+  font-weight: 600;
+}
+
+.contact-grid {
+  display: grid;
+  gap: 32px;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  align-items: start;
+}
+
+.contact-form {
+  padding: 36px;
+  border-radius: var(--radius-lg);
+  background: var(--surface-50);
+  border: 1px solid var(--border-color);
+  backdrop-filter: blur(16px);
+  box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: 20px;
+}
+
+.form-row {
+  display: grid;
+  gap: 8px;
+}
+
+label {
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+input,
+textarea {
+  width: 100%;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  padding: 12px 16px;
+  background: rgba(255, 255, 255, 0.7);
+  color: inherit;
+  font-family: inherit;
+  transition: border-color var(--transition-base), box-shadow var(--transition-base);
+}
+
+[data-theme='dark'] input,
+[data-theme='dark'] textarea,
+@media (prefers-color-scheme: dark) {
+  input,
+  textarea {
+    background: rgba(15, 23, 42, 0.55);
+  }
+}
+
+input:focus,
+textarea:focus {
+  outline: none;
+  border-color: var(--accent-400);
+  box-shadow: 0 0 0 4px rgba(79, 55, 255, 0.15);
+}
+
+.form-hint {
+  font-size: 0.85rem;
+  color: var(--text-tertiary);
+  margin-top: -8px;
+}
+
+.contact-info {
+  display: grid;
+  gap: 20px;
+}
+
+.info-card {
+  padding: 24px;
+  border-radius: var(--radius-lg);
+  background: var(--surface-50);
+  border: 1px solid var(--border-color);
+  backdrop-filter: blur(14px);
+  display: grid;
+  gap: 10px;
+}
+
+.site-footer {
+  border-top: 1px solid var(--border-color);
+  padding: 48px 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  color: var(--text-tertiary);
+}
+
+.footer-links {
+  display: flex;
+  gap: 18px;
+  flex-wrap: wrap;
+}
+
+.search-results {
+  position: fixed;
+  top: 80px;
+  right: 24px;
+  width: min(360px, 90vw);
+  max-height: 70vh;
+  overflow-y: auto;
+  background: var(--surface-50);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border-color);
+  box-shadow: var(--shadow-hard);
+  backdrop-filter: blur(18px);
+  padding: 24px;
+  display: grid;
+  gap: 16px;
+  z-index: 10;
+}
+
+.results-title {
+  margin: 0;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  font-size: 0.85rem;
+  color: var(--text-tertiary);
+}
+
+#results-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 12px;
+}
+
+#results-list li {
+  display: grid;
+  gap: 4px;
+}
+
+#results-list a {
+  font-weight: 600;
+  color: var(--accent-500);
+}
+
+.snippet {
+  font-size: 0.85rem;
+  color: var(--text-tertiary);
+}
+
+.highlight {
+  outline: 2px solid var(--accent-400);
+  outline-offset: 6px;
+  border-radius: var(--radius-lg);
+  transition: outline var(--transition-base);
+}
+
+.menu-toggle {
+  display: none;
+  border: none;
+  background: rgba(79, 55, 255, 0.1);
+  color: var(--accent-500);
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.menu-toggle svg {
+  width: 28px;
+  height: 28px;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+@media (max-width: 960px) {
+  .top-nav {
+    grid-template-columns: auto auto;
+    grid-template-areas:
+      'logo actions'
+      'menu menu';
+    justify-content: space-between;
+  }
+
+  .logo {
+    grid-area: logo;
+  }
+
+  .nav-actions {
+    grid-area: actions;
+    justify-content: flex-end;
+  }
+
+  .menu-toggle {
+    display: inline-flex;
+  }
+
+  .nav-links {
+    grid-area: menu;
+    display: none;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+    padding: 16px;
+    border-radius: var(--radius-lg);
+    background: var(--surface-50);
+    border: 1px solid var(--border-color);
+    backdrop-filter: blur(16px);
+    animation: fadeIn 180ms ease;
+  }
+
+  .nav-links.open {
+    display: flex;
+  }
+
+  #site-search {
+    width: 180px;
+  }
+}
+
+@media (max-width: 720px) {
+  .section {
+    padding: 72px 20px;
+  }
+
+  .hero {
+    margin-top: 32px;
+  }
+
+  .hero-content h1 {
+    font-size: clamp(2.4rem, 8vw, 3.4rem);
+  }
+
+  .floating-card {
+    max-width: 320px;
+  }
+
+  .timeline-item {
+    grid-template-columns: 1fr;
+  }
+
+  .timeline-year {
+    order: 2;
+  }
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,0 +1,263 @@
+const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
+const prefersLight = window.matchMedia('(prefers-color-scheme: light)');
+const root = document.documentElement;
+const body = document.body;
+const themeToggle = document.getElementById('theme-toggle');
+const searchInput = document.getElementById('site-search');
+const menuToggle = document.querySelector('.menu-toggle');
+const navLinks = document.getElementById('nav-links');
+const searchResults = document.getElementById('search-results');
+const resultsList = document.getElementById('results-list');
+const sections = [...document.querySelectorAll('section')];
+
+const STORAGE_KEY = 'adrian-theme-preference-v1';
+
+const sectionIndex = sections.map((section) => ({
+  id: section.id,
+  title: section.querySelector('h2')?.textContent ?? section.dataset.sectionTitle,
+  description: section.querySelector('p')?.textContent ?? '',
+}));
+
+const projectCards = [...document.querySelectorAll('.project-card')];
+const journalCards = [...document.querySelectorAll('.journal-card')];
+const favoriteCards = [...document.querySelectorAll('.favorite-card')];
+
+function setTheme(theme) {
+  if (theme) {
+    root.setAttribute('data-theme', theme);
+  } else {
+    root.removeAttribute('data-theme');
+  }
+}
+
+function loadStoredTheme() {
+  try {
+    return localStorage.getItem(STORAGE_KEY);
+  } catch (error) {
+    console.warn('Kann gespeicherte Einstellungen nicht lesen.', error);
+    return null;
+  }
+}
+
+function storeTheme(theme) {
+  try {
+    if (theme) {
+      localStorage.setItem(STORAGE_KEY, theme);
+    } else {
+      localStorage.removeItem(STORAGE_KEY);
+    }
+  } catch (error) {
+    console.warn('Kann Einstellungen nicht speichern.', error);
+  }
+}
+
+function resolveInitialTheme() {
+  const stored = loadStoredTheme();
+  if (stored) {
+    setTheme(stored);
+    return;
+  }
+  if (prefersDark.matches) {
+    setTheme('dark');
+  } else if (prefersLight.matches) {
+    setTheme('light');
+  }
+}
+
+function toggleTheme() {
+  const current = root.getAttribute('data-theme');
+  const next = current === 'dark' ? 'light' : 'dark';
+  setTheme(next);
+  storeTheme(next);
+}
+
+themeToggle?.addEventListener('click', toggleTheme);
+
+prefersDark.addEventListener('change', (event) => {
+  if (!loadStoredTheme()) {
+    setTheme(event.matches ? 'dark' : 'light');
+  }
+});
+
+window.addEventListener('DOMContentLoaded', () => {
+  resolveInitialTheme();
+  const year = document.getElementById('year');
+  if (year) {
+    year.textContent = new Date().getFullYear();
+  }
+});
+
+menuToggle?.addEventListener('click', () => {
+  const expanded = menuToggle.getAttribute('aria-expanded') === 'true';
+  menuToggle.setAttribute('aria-expanded', String(!expanded));
+  navLinks?.classList.toggle('open', !expanded);
+});
+
+function searchSections(query) {
+  const normalized = query.trim().toLowerCase();
+  if (!normalized) {
+    searchResults.hidden = true;
+    resultsList.innerHTML = '';
+    removeHighlights();
+    return;
+  }
+
+  const matches = sectionIndex
+    .map((section) => {
+      const text = `${section.title} ${section.description}`.toLowerCase();
+      return text.includes(normalized) ? section : null;
+    })
+    .filter(Boolean);
+
+  resultsList.innerHTML = '';
+  if (!matches.length) {
+    searchResults.hidden = false;
+    const emptyState = document.createElement('li');
+    emptyState.textContent = 'Keine Treffer gefunden.';
+    resultsList.appendChild(emptyState);
+    removeHighlights();
+    return;
+  }
+
+  matches.forEach((match) => {
+    const listItem = document.createElement('li');
+    const link = document.createElement('a');
+    link.href = `#${match.id}`;
+    link.textContent = match.title;
+    link.addEventListener('click', () => {
+      searchResults.hidden = true;
+      removeHighlights();
+      highlightSection(match.id);
+    });
+    const snippet = document.createElement('span');
+    snippet.textContent = match.description;
+    snippet.classList.add('snippet');
+    listItem.appendChild(link);
+    listItem.appendChild(snippet);
+    resultsList.appendChild(listItem);
+  });
+
+  searchResults.hidden = false;
+}
+
+function highlightSection(id) {
+  const section = document.getElementById(id);
+  if (section) {
+    section.classList.add('highlight');
+    section.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    setTimeout(() => {
+      section.classList.remove('highlight');
+    }, 2400);
+  }
+}
+
+function removeHighlights() {
+  sections.forEach((section) => section.classList.remove('highlight'));
+}
+
+searchInput?.addEventListener('input', (event) => {
+  const value = event.target.value;
+  searchSections(value);
+  searchProjects(value);
+  searchJournal(value);
+  searchFavorites(value);
+});
+
+searchInput?.addEventListener('focus', () => {
+  if (searchInput.value) {
+    searchSections(searchInput.value);
+  }
+});
+
+window.addEventListener('click', (event) => {
+  if (!searchResults.contains(event.target) && event.target !== searchInput) {
+    searchResults.hidden = true;
+  }
+});
+
+// Motion preference: disable animations when user prefers reduced motion
+const mediaMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
+if (mediaMotion.matches) {
+  disableAnimations();
+}
+mediaMotion.addEventListener('change', (event) => {
+  if (event.matches) {
+    disableAnimations();
+  } else {
+    enableAnimations();
+  }
+});
+
+let originalTransitions = [];
+
+function disableAnimations() {
+  originalTransitions = [];
+  document.querySelectorAll('*').forEach((element) => {
+    const transition = getComputedStyle(element).transition;
+    const animation = getComputedStyle(element).animation;
+    originalTransitions.push({ element, transition, animation });
+    element.style.transition = 'none';
+    element.style.animation = 'none';
+  });
+}
+
+function enableAnimations() {
+  originalTransitions.forEach(({ element, transition, animation }) => {
+    element.style.transition = transition;
+    element.style.animation = animation;
+  });
+  originalTransitions = [];
+}
+
+function searchProjects(query) {
+  const normalized = query.trim().toLowerCase();
+  if (!normalized) {
+    projectCards.forEach((card) => (card.hidden = false));
+    return;
+  }
+
+  projectCards.forEach((card) => {
+    const keywords = card.dataset.keywords ?? '';
+    const text = `${card.textContent} ${keywords}`.toLowerCase();
+    card.hidden = !text.includes(normalized);
+  });
+}
+
+function searchJournal(query) {
+  const normalized = query.trim().toLowerCase();
+  if (!normalized) {
+    journalCards.forEach((card) => (card.hidden = false));
+    return;
+  }
+
+  journalCards.forEach((card) => {
+    const keywords = card.dataset.keywords ?? '';
+    const text = `${card.textContent} ${keywords}`.toLowerCase();
+    card.hidden = !text.includes(normalized);
+  });
+}
+
+function searchFavorites(query) {
+  const normalized = query.trim().toLowerCase();
+  if (!normalized) {
+    favoriteCards.forEach((card) => (card.hidden = false));
+    return;
+  }
+
+  favoriteCards.forEach((card) => {
+    const text = card.textContent.toLowerCase();
+    card.hidden = !text.includes(normalized);
+  });
+}
+
+// Close search results with Escape key
+searchInput?.addEventListener('keydown', (event) => {
+  if (event.key === 'Escape') {
+    searchInput.value = '';
+    searchResults.hidden = true;
+    removeHighlights();
+    searchProjects('');
+    searchJournal('');
+    searchFavorites('');
+  }
+});

--- a/datenschutz.html
+++ b/datenschutz.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html lang="de">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Datenschutzerklärung von Adrian Dylan-Wulff." />
+    <title>Datenschutz – Adrian Dylan-Wulff</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@300;400;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="assets/css/styles.css" />
+  </head>
+  <body>
+    <header class="site-header" id="top">
+      <nav class="top-nav" aria-label="Hauptnavigation">
+        <a href="index.html" class="logo" aria-label="Zur Startseite">Adrian<span>.</span></a>
+        <button class="menu-toggle" aria-expanded="false" aria-controls="nav-links">
+          <span class="sr-only">Menü öffnen</span>
+          <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M4 6h16M4 12h16M4 18h16" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+          </svg>
+        </button>
+        <div class="nav-links" id="nav-links">
+          <a href="index.html#about">Über mich</a>
+          <a href="index.html#projects">Projekte</a>
+          <a href="index.html#journal">Journal</a>
+          <a href="index.html#contact">Kontakt</a>
+        </div>
+        <div class="nav-actions">
+          <input type="search" id="site-search" placeholder="Inhalten suchen…" aria-label="Inhalten suchen" />
+          <button id="theme-toggle" class="icon-button" aria-label="Design wechseln">
+            <svg class="icon-sun" viewBox="0 0 24 24" aria-hidden="true">
+              <path
+                d="M12 4.5V2m0 20v-2.5m7.5-7.5H22M2 12h2.5m14.1-5.6 1.8-1.8M4.6 19.4l1.8-1.8m0-9.2L4.6 6.4m14.8 14.8-1.8-1.8M12 7.5a4.5 4.5 0 1 1 0 9 4.5 4.5 0 0 1 0-9Z"
+              />
+            </svg>
+            <svg class="icon-moon" viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M21 14.5A9 9 0 0 1 9.5 3 7.5 7.5 0 1 0 21 14.5Z" />
+            </svg>
+          </button>
+        </div>
+      </nav>
+      <section class="hero legal-hero" data-section-title="Datenschutz">
+        <div class="hero-content">
+          <p class="eyebrow">Sicherheit &amp; Vertrauen</p>
+          <h1>Datenschutzerklärung</h1>
+          <p>Hier erfährst du, welche Daten auf dieser privaten Webseite verarbeitet werden.</p>
+        </div>
+      </section>
+    </header>
+
+    <main>
+      <section class="section" id="privacy" data-section-title="Datenschutzerklärung">
+        <div class="legal-content">
+          <h2>1. Verantwortliche Person</h2>
+          <p>
+            Verantwortlich für die Datenverarbeitung ist Adrian Dylan-Wulff.<br />
+            Kontakt: <a href="mailto:anfrage@adriandylanwulf.de">anfrage@adriandylanwulf.de</a>
+          </p>
+
+          <h2>2. Allgemeine Hinweise zur Datenverarbeitung</h2>
+          <p>
+            Diese Webseite dient rein privaten Zwecken. Es werden keine personenbezogenen Daten automatisiert analysiert, profiliert oder für Werbung genutzt.
+          </p>
+
+          <h2>3. Server-Logs</h2>
+          <p>
+            Beim Aufruf der Seite werden serverseitig temporäre Logfiles (z. B. IP-Adresse, Datum, Uhrzeit, Browsertyp) gespeichert. Diese Daten werden ausschließlich zur Sicherstellung eines störungsfreien Betriebs benötigt und automatisch gelöscht.
+          </p>
+
+          <h2>4. Kontaktaufnahme</h2>
+          <p>
+            Wenn du per E-Mail oder über das Formular Kontakt aufnimmst, werden die Angaben ausschließlich zur Bearbeitung deiner Anfrage verwendet. Eine Weitergabe an Dritte findet nicht statt.
+          </p>
+
+          <h2>5. Eingesetzte Dienste &amp; Cookies</h2>
+          <p>
+            Es werden keine Tracking-Cookies, Analyse- oder Marketingdienste eingesetzt. Lediglich technisch notwendige Cookies deines Browsers können entstehen (z. B. zur Speicherung deiner Theme-Präferenz im Local Storage).
+          </p>
+
+          <h2>6. Local Storage &amp; Themes</h2>
+          <p>
+            Zur Speicherung deiner Design-Einstellung (Hell/Dunkel) wird ein Eintrag im Local Storage deines Browsers abgelegt. Du kannst diese Einstellung jederzeit über die Browser-Einstellungen löschen.
+          </p>
+
+          <h2>7. Deine Rechte</h2>
+          <p>
+            Du hast jederzeit das Recht auf Auskunft über die bei mir gespeicherten personenbezogenen Daten sowie ein Recht auf Berichtigung, Sperrung oder Löschung. Schreibe dafür einfach an
+            <a href="mailto:anfrage@adriandylanwulf.de">anfrage@adriandylanwulf.de</a>.
+          </p>
+
+          <h2>8. Aktualität und Änderung dieser Hinweise</h2>
+          <p>
+            Diese Datenschutzerklärung wird bei Bedarf angepasst, damit sie stets den aktuellen rechtlichen Anforderungen entspricht. Letzte Aktualisierung: April 2025.
+          </p>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <p>© <span id="year"></span> Adrian Dylan-Wulff. Alle Rechte vorbehalten.</p>
+      <div class="footer-links">
+        <a href="#top">Nach oben</a>
+        <a href="index.html">Zur Startseite</a>
+        <a href="impressum.html">Impressum</a>
+      </div>
+    </footer>
+
+    <div class="search-results" id="search-results" hidden>
+      <p class="results-title">Suchergebnisse</p>
+      <ul id="results-list"></ul>
+    </div>
+
+    <script src="assets/js/main.js" type="module"></script>
+  </body>
+</html>

--- a/impressum.html
+++ b/impressum.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="de">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Impressum von Adrian Dylan-Wulff." />
+    <title>Impressum – Adrian Dylan-Wulff</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@300;400;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="assets/css/styles.css" />
+  </head>
+  <body>
+    <header class="site-header" id="top">
+      <nav class="top-nav" aria-label="Hauptnavigation">
+        <a href="index.html" class="logo" aria-label="Zur Startseite">Adrian<span>.</span></a>
+        <button class="menu-toggle" aria-expanded="false" aria-controls="nav-links">
+          <span class="sr-only">Menü öffnen</span>
+          <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M4 6h16M4 12h16M4 18h16" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+          </svg>
+        </button>
+        <div class="nav-links" id="nav-links">
+          <a href="index.html#about">Über mich</a>
+          <a href="index.html#projects">Projekte</a>
+          <a href="index.html#journal">Journal</a>
+          <a href="index.html#contact">Kontakt</a>
+        </div>
+        <div class="nav-actions">
+          <input type="search" id="site-search" placeholder="Inhalten suchen…" aria-label="Inhalten suchen" />
+          <button id="theme-toggle" class="icon-button" aria-label="Design wechseln">
+            <svg class="icon-sun" viewBox="0 0 24 24" aria-hidden="true">
+              <path
+                d="M12 4.5V2m0 20v-2.5m7.5-7.5H22M2 12h2.5m14.1-5.6 1.8-1.8M4.6 19.4l1.8-1.8m0-9.2L4.6 6.4m14.8 14.8-1.8-1.8M12 7.5a4.5 4.5 0 1 1 0 9 4.5 4.5 0 0 1 0-9Z"
+              />
+            </svg>
+            <svg class="icon-moon" viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M21 14.5A9 9 0 0 1 9.5 3 7.5 7.5 0 1 0 21 14.5Z" />
+            </svg>
+          </button>
+        </div>
+      </nav>
+      <section class="hero legal-hero" data-section-title="Impressum">
+        <div class="hero-content">
+          <p class="eyebrow">Transparenz &amp; Hinweise</p>
+          <h1>Impressum</h1>
+          <p>Diese private Webseite wird von Adrian Dylan-Wulff betrieben.</p>
+        </div>
+      </section>
+    </header>
+
+    <main>
+      <section class="section" id="impressum" data-section-title="Rechtliches">
+        <div class="legal-content">
+          <h2>Angaben gemäß § 5 TMG</h2>
+          <p>
+            Adrian Dylan-Wulff<br />
+            Postanschrift wird auf Anfrage entsprechend der gesetzlichen Vorgaben mitgeteilt.
+          </p>
+
+          <h2>Kontakt</h2>
+          <p>
+            E-Mail: <a href="mailto:anfrage@adriandylanwulf.de">anfrage@adriandylanwulf.de</a>
+          </p>
+
+          <h2>Hinweis auf den privaten Charakter</h2>
+          <p>
+            Diese Seite verfolgt keinen kommerziellen Zweck. Inhalte spiegeln persönliche Interessen, Projekte und Empfehlungen wider.
+          </p>
+
+          <h2>Verantwortlich für den Inhalt nach § 55 Abs. 2 RStV</h2>
+          <p>
+            Adrian Dylan-Wulff<br />
+            E-Mail: <a href="mailto:anfrage@adriandylanwulf.de">anfrage@adriandylanwulf.de</a>
+          </p>
+
+          <h2>Haftung für Inhalte</h2>
+          <p>
+            Die Inhalte dieser Seite wurden mit größter Sorgfalt erstellt. Für die Richtigkeit, Vollständigkeit und Aktualität der Inhalte kann jedoch keine Gewähr übernommen werden.
+          </p>
+
+          <h2>Haftung für Links</h2>
+          <p>
+            Diese Seite enthält Links zu externen Websites Dritter, auf deren Inhalte kein Einfluss besteht. Für die Inhalte der verlinkten Seiten ist stets der jeweilige Anbieter oder Betreiber verantwortlich.
+          </p>
+
+          <h2>Urheberrecht</h2>
+          <p>
+            Die durch den Seitenbetreiber erstellten Inhalte und Werke auf diesen Seiten unterliegen dem deutschen Urheberrecht. Beiträge Dritter sind als solche gekennzeichnet. Eine Vervielfältigung, Bearbeitung oder Verbreitung bedarf der schriftlichen Zustimmung.
+          </p>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <p>© <span id="year"></span> Adrian Dylan-Wulff. Alle Rechte vorbehalten.</p>
+      <div class="footer-links">
+        <a href="#top">Nach oben</a>
+        <a href="index.html">Zur Startseite</a>
+        <a href="datenschutz.html">Datenschutz</a>
+      </div>
+    </footer>
+
+    <div class="search-results" id="search-results" hidden>
+      <p class="results-title">Suchergebnisse</p>
+      <ul id="results-list"></ul>
+    </div>
+
+    <script src="assets/js/main.js" type="module"></script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,328 @@
+<!DOCTYPE html>
+<html lang="de">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Persönliche Homepage von Adrian Dylan-Wulff – Geschichten, Projekte, Musik und Kontakt in einem modernen, adaptiven Design."
+    />
+    <title>Adrian Dylan-Wulff – Private Homepage</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@300;400;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="assets/css/styles.css" />
+  </head>
+  <body>
+    <header class="site-header" id="top">
+      <nav class="top-nav" aria-label="Hauptnavigation">
+        <a href="#top" class="logo" aria-label="Startseite">Adrian<span>.</span></a>
+        <button class="menu-toggle" aria-expanded="false" aria-controls="nav-links">
+          <span class="sr-only">Menü öffnen</span>
+          <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M4 6h16M4 12h16M4 18h16" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+          </svg>
+        </button>
+        <div class="nav-links" id="nav-links">
+          <a href="#about">Über mich</a>
+          <a href="#skills">Skills</a>
+          <a href="#timeline">Timeline</a>
+          <a href="#projects">Projekte</a>
+          <a href="#journal">Journal</a>
+          <a href="#favorites">Lieblingsdinge</a>
+          <a href="#contact">Kontakt</a>
+        </div>
+        <div class="nav-actions">
+          <input type="search" id="site-search" placeholder="Inhalten suchen…" aria-label="Inhalten suchen" />
+          <button id="theme-toggle" class="icon-button" aria-label="Design wechseln">
+            <svg class="icon-sun" viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M12 4.5V2m0 20v-2.5m7.5-7.5H22M2 12h2.5m14.1-5.6 1.8-1.8M4.6 19.4l1.8-1.8m0-9.2L4.6 6.4m14.8 14.8-1.8-1.8M12 7.5a4.5 4.5 0 1 1 0 9 4.5 4.5 0 0 1 0-9Z" />
+            </svg>
+            <svg class="icon-moon" viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M21 14.5A9 9 0 0 1 9.5 3 7.5 7.5 0 1 0 21 14.5Z" />
+            </svg>
+          </button>
+        </div>
+      </nav>
+      <section class="hero" data-section-title="Hero">
+        <div class="hero-content">
+          <p class="eyebrow">Moin, ich bin Adrian Dylan-Wulff</p>
+          <h1>Ich erzähle digitale Geschichten voller Herz, Klang und Neugier.</h1>
+          <p>
+            Dies ist mein persönlicher Ort im Netz. Hier sammle ich Projekte, Notizen und Lieblingsmomente – alles, was mich antreibt zwischen Design, Musik und spontanen Roadtrips. Mach es dir gemütlich.
+          </p>
+          <div class="hero-actions">
+            <a class="button primary" href="#about">Mehr über mich</a>
+            <a class="button secondary" href="#contact">Eine Nachricht schicken</a>
+          </div>
+        </div>
+        <div class="hero-visual" aria-hidden="true">
+          <div class="floating-card">
+            <p>Aktuell auf meiner Liste</p>
+            <h2>Mixtape 03</h2>
+            <p>
+              Eine handverlesene Playlist aus sanften Beats und akustischen Sessions – perfekt für späte Design-Nächte.
+            </p>
+            <a href="#journal" class="card-link">Reinhorchen →</a>
+          </div>
+          <div class="orb orb-1"></div>
+          <div class="orb orb-2"></div>
+        </div>
+      </section>
+    </header>
+
+    <main>
+      <section id="about" class="section" data-section-title="Über mich">
+        <div class="section-header">
+          <span class="section-eyebrow">Überblick</span>
+          <h2>Ein persönlicher Platz im Netz</h2>
+        </div>
+        <div class="about-grid">
+          <article class="about-card">
+            <h3>Ich in drei Zeilen</h3>
+            <p>
+              Adrian, 90er-Kid, Mensch mit einer Vorliebe für ehrliche Stories. Ich kombiniere Design, Musik und kleine Abenteuer, um Ideen spürbar zu machen.
+            </p>
+          </article>
+          <article class="about-card">
+            <h3>Werte</h3>
+            <p>
+              Empathie vor Ego, Freundlichkeit vor Geschwindigkeit. Ich mag es, wenn Technologien Menschen stärken, nicht stressen – deshalb stehen Zugänglichkeit und Sicherheit immer oben.
+            </p>
+          </article>
+          <article class="about-card">
+            <h3>Aktuell</h3>
+            <p>
+              Ich arbeite an kleinen Tools für Musiker:innen, an Visuals für Podcasts und halte meine Kamera bereit für unerwartete Momente unterwegs.
+            </p>
+          </article>
+        </div>
+      </section>
+
+      <section id="skills" class="section" data-section-title="Skills">
+        <div class="section-header">
+          <span class="section-eyebrow">Toolset</span>
+          <h2>Womit ich besonders gern arbeite</h2>
+          <p>Ein Mix aus Code, Sound und Community – immer mit einem Auge für Details und Stimmung.</p>
+        </div>
+        <div class="chips" role="list">
+          <span role="listitem">UX Research</span>
+          <span role="listitem">Creative Coding</span>
+          <span role="listitem">Design Systeme</span>
+          <span role="listitem">React &amp; TypeScript</span>
+          <span role="listitem">Next.js</span>
+          <span role="listitem">Node.js</span>
+          <span role="listitem">Tailwind &amp; CSS-Architektur</span>
+          <span role="listitem">Audio Storytelling</span>
+          <span role="listitem">Barrierefreiheit (WCAG)</span>
+          <span role="listitem">AI-unterstützte Workflows</span>
+        </div>
+      </section>
+
+      <section id="timeline" class="section" data-section-title="Timeline">
+        <div class="section-header">
+          <span class="section-eyebrow">Meilensteine</span>
+          <h2>Momente, die mich geprägt haben</h2>
+        </div>
+        <div class="timeline">
+          <article class="timeline-item">
+            <div class="timeline-year">2025</div>
+            <div class="timeline-content">
+              <h3>Eigenes Audio-Projekt gestartet</h3>
+              <p>Ich produziere ein intimes Podcast-Format über kreative Routinen und was Musik mit Fokus macht.</p>
+            </div>
+          </article>
+          <article class="timeline-item">
+            <div class="timeline-year">2023</div>
+            <div class="timeline-content">
+              <h3>Freelance-Season verlängert</h3>
+              <p>Gemeinsam mit freund*innen entstehen kleine Tools für Künstler:innen – vom EPK-Generator bis zum On-Tour-Blog.</p>
+            </div>
+          </article>
+          <article class="timeline-item">
+            <div class="timeline-year">2020</div>
+            <div class="timeline-content">
+              <h3>Der Sprung in die Selbstständigkeit</h3>
+              <p>Ich verbinde Design, Frontend und Sounddesign, um Projekte komplett erlebbar zu machen.</p>
+            </div>
+          </article>
+          <article class="timeline-item">
+            <div class="timeline-year">2018</div>
+            <div class="timeline-content">
+              <h3>Erste Schritte im Web</h3>
+              <p>Ein Blog über Mixtapes wurde zur Spielwiese für Design und Geschichten – und der Ausgangspunkt für heute.</p>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <section id="projects" class="section" data-section-title="Projekte">
+        <div class="section-header">
+          <span class="section-eyebrow">Showcase</span>
+          <h2>Was ich aktuell baue</h2>
+          <p>Eine kleine Auswahl an Projekten, an denen ich mit viel Liebe zum Detail arbeite.</p>
+        </div>
+        <div class="project-grid">
+          <article class="project-card" data-keywords="ki analyse datenschutz">
+            <div class="project-meta">
+              <span class="project-year">2025</span>
+              <span class="project-type">AI Platform</span>
+            </div>
+            <h3>Sense &amp; Simplicity</h3>
+            <p>Datenschutzfreundliche Analyse-Suite mit explainable AI und adaptivem Interface.</p>
+            <ul>
+              <li>Privacy-by-Design</li>
+              <li>Progressive Web App</li>
+              <li>Design Tokens</li>
+            </ul>
+            <a class="card-link" href="#contact">Projekt anfragen →</a>
+          </article>
+          <article class="project-card" data-keywords="nachhaltigkeit energie dashboard">
+            <div class="project-meta">
+              <span class="project-year">2024</span>
+              <span class="project-type">Dashboard</span>
+            </div>
+            <h3>Green Pulse</h3>
+            <p>Realtime-Energie-Monitoring mit Fokus auf Nachhaltigkeitsziele und Storytelling.</p>
+            <ul>
+              <li>Carbon Analytics</li>
+              <li>Micro-Interactions</li>
+              <li>Accessible Charts</li>
+            </ul>
+            <a class="card-link" href="#contact">Projekt anfragen →</a>
+          </article>
+          <article class="project-card" data-keywords="education community design system">
+            <div class="project-meta">
+              <span class="project-year">2023</span>
+              <span class="project-type">Design System</span>
+            </div>
+            <h3>Learnflow</h3>
+            <p>Community-Plattform mit modularem Design-System und skalierbarer Content-Architektur.</p>
+            <ul>
+              <li>Design Ops</li>
+              <li>Content Strategy</li>
+              <li>Realtime Collaboration</li>
+            </ul>
+            <a class="card-link" href="#contact">Projekt anfragen →</a>
+          </article>
+        </div>
+      </section>
+
+      <section id="journal" class="section" data-section-title="Journal">
+        <div class="section-header">
+          <span class="section-eyebrow">Notizen</span>
+          <h2>Frische Einträge aus meinem Journal</h2>
+          <p>Gedanken, Playlists und kleine Hacks, die ich teilen möchte.</p>
+        </div>
+        <div class="journal-grid">
+          <article class="journal-card" data-keywords="playlist musik fokussieren">
+            <h3>Mixtape 03 – Fokus Edition</h3>
+            <p>Ein Mix aus Lo-Fi, Soul und Ambient, der mich beim Coden begleitet. Mit Download-Link und Tracklist.</p>
+            <time datetime="2025-04-12">12. April 2025</time>
+            <a class="card-link" href="#contact">Feedback da lassen →</a>
+          </article>
+          <article class="journal-card" data-keywords="fotografie roadtrip inspiration">
+            <h3>Analog auf Achse</h3>
+            <p>Meine liebsten Roadtrip-Fotos inklusive Preset, das ich für warme Töne entwickelt habe.</p>
+            <time datetime="2025-03-22">22. März 2025</time>
+            <a class="card-link" href="#contact">Preset anfragen →</a>
+          </article>
+          <article class="journal-card" data-keywords="produktivität ritual morgenroutine">
+            <h3>Meine ruhige Morgenroutine</h3>
+            <p>30 Minuten Offline-Zeit, Journaling und ein Song auf Repeat – kleine Rituale, die Projekte sanft starten lassen.</p>
+            <time datetime="2025-02-02">2. Februar 2025</time>
+            <a class="card-link" href="#contact">Routine teilen →</a>
+          </article>
+        </div>
+      </section>
+
+      <section id="favorites" class="section" data-section-title="Lieblingsdinge">
+        <div class="section-header">
+          <span class="section-eyebrow">Moodboard</span>
+          <h2>Kleine Dinge, die mich glücklich machen</h2>
+          <p>Ein paar Schnelltipps, falls du mich kennenlernen möchtest.</p>
+        </div>
+        <div class="favorites-grid" role="list">
+          <article class="favorite-card" role="listitem">
+            <h3>Sound</h3>
+            <p>Schimmernde Gitarren, warme Synths und Jazz-Hop. Musik ist mein Taktgeber.</p>
+          </article>
+          <article class="favorite-card" role="listitem">
+            <h3>Unterwegs</h3>
+            <p>Longboard unter den Füßen, Kamera im Rucksack, spontane Sonnenuntergänge inklusive.</p>
+          </article>
+          <article class="favorite-card" role="listitem">
+            <h3>Community</h3>
+            <p>Ich liebe es, Sessions mit Freund*innen zu hosten, Wissen zu teilen und Menschen zu vernetzen.</p>
+          </article>
+          <article class="favorite-card" role="listitem">
+            <h3>Technik</h3>
+            <p>Privacy-first Tools, modulare Systeme und offene Schnittstellen. Sicher, flexibel, freundlich.</p>
+          </article>
+        </div>
+      </section>
+
+      <section id="contact" class="section" data-section-title="Kontakt">
+        <div class="section-header">
+          <span class="section-eyebrow">Sag Hallo</span>
+          <h2>Lust auf Austausch?</h2>
+          <p>Ob Projektidee, Lieblingssong oder Roadtrip-Tipp – ich freue mich über deine Nachricht.</p>
+        </div>
+        <div class="contact-grid">
+          <form class="contact-form" aria-label="Kontaktformular">
+            <div class="form-row">
+              <label for="name">Name</label>
+              <input type="text" id="name" name="name" autocomplete="name" placeholder="Vor- und Nachname" required />
+            </div>
+            <div class="form-row">
+              <label for="email">E-Mail</label>
+              <input type="email" id="email" name="email" autocomplete="email" placeholder="name@example.com" required />
+            </div>
+            <div class="form-row">
+              <label for="message">Nachricht</label>
+              <textarea id="message" name="message" rows="4" placeholder="Erzähl mir von deinem Projekt…" required></textarea>
+            </div>
+            <button type="submit" class="button primary">Nachricht senden</button>
+            <p class="form-hint">Das Formular speichert keine Daten dauerhaft. Du erhältst eine Kopie zur Bestätigung.</p>
+          </form>
+          <aside class="contact-info" aria-label="Kontaktinformationen">
+            <div class="info-card">
+              <h3>Direkter Draht</h3>
+              <p><strong>E-Mail:</strong> <a href="mailto:anfrage@adriandylanwulf.de">anfrage@adriandylanwulf.de</a></p>
+              <p><strong>Standort:</strong> Oft unterwegs zwischen Hamburg und der Nordsee.</p>
+            </div>
+            <div class="info-card">
+              <h3>Social</h3>
+              <ul>
+                <li><a href="https://www.linkedin.com" target="_blank" rel="noreferrer">LinkedIn</a></li>
+                <li><a href="https://www.github.com" target="_blank" rel="noreferrer">GitHub</a></li>
+                <li><a href="https://www.dribbble.com" target="_blank" rel="noreferrer">Dribbble</a></li>
+              </ul>
+            </div>
+            <div class="info-card">
+              <h3>Mini-Newsletter</h3>
+              <p>Dreimal im Jahr verschicke ich ein freundliches Update mit Musik, Tools und Projekten.</p>
+              <button class="button secondary" type="button">Auf die Liste setzen</button>
+            </div>
+          </aside>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <p>© <span id="year"></span> Adrian Dylan-Wulff. Alle Rechte vorbehalten.</p>
+      <div class="footer-links">
+        <a href="#top">Nach oben</a>
+        <a href="impressum.html">Impressum</a>
+        <a href="datenschutz.html">Datenschutz</a>
+      </div>
+    </footer>
+
+    <div class="search-results" id="search-results" hidden>
+      <p class="results-title">Suchergebnisse</p>
+      <ul id="results-list"></ul>
+    </div>
+
+    <script src="assets/js/main.js" type="module"></script>
+  </body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://adriandylanwulf.de/</loc>
+    <lastmod>2025-10-05</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://adriandylanwulf.de/impressum.html</loc>
+    <lastmod>2025-10-05</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+  <url>
+    <loc>https://adriandylanwulf.de/datenschutz.html</loc>
+    <lastmod>2025-10-05</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- rework the single-page personal site for Adrian with updated copy plus new journal and favorites sections
- reorganize assets into css/js folders and enhance styling to support the refreshed layout
- add dedicated impressum and privacy pages along with a sitemap for search engine visibility

## Testing
- No automated tests were run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68e1b63a66b083258009af249121fca0