### PR TITLE
Simplify Adrian landing page experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-# Homepage
+# Adrian Dylan Wulf – Private Landingpage
+
+Eine ruhige, persönliche Landingpage mit hell/dunkel Modus, klarer Typografie und leichtgewichtigen Abschnitten für Momente,
+Gedanken und Kontakt.
+
+## Inhalt
+
+- `index.html` – Startseite mit Intro, Kurznotizen und Kontakt
+- `impressum.html`, `datenschutz.html` – rechtliche Einzelseiten im gleichen Look
+- `assets/css/styles.css` – globales Stylesheet für Layout, Farben und Komponenten
+- `assets/js/main.js` – kleine Helfer für Theme-Umschaltung und Jahreszahl im Footer
+- `sitemap.xml` – Sitemap für Suchmaschinen
+
+## Lokale Vorschau
+
+Die Seite ist statisch und benötigt keinen Build-Prozess.
+
+```bash
+python -m http.server 8000
+```
+
+Danach im Browser `http://localhost:8000` öffnen.
+
+## Anpassung
+
+Die Texte lassen sich direkt in den HTML-Dateien anpassen. Für neue Sektionen können bestehende Karten (z. B. aus dem
+`about`-Bereich) dupliziert werden. Assets wie Bilder oder weitere Schriftarten lassen sich unter `assets/` ergänzen.

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,0 +1,375 @@
+:root {
+  --font-base: 'Manrope', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --font-accent: 'Playfair Display', 'Georgia', serif;
+  --color-bg: #f6f7f9;
+  --color-bg-soft: rgba(255, 255, 255, 0.7);
+  --color-text: #1d1e24;
+  --color-muted: #525667;
+  --color-accent: #3a6cff;
+  --color-border: rgba(30, 34, 58, 0.08);
+  --shadow-soft: 0 20px 40px rgba(15, 22, 45, 0.12);
+}
+
+[data-theme='dark'] {
+  --color-bg: #0f1425;
+  --color-bg-soft: rgba(18, 22, 37, 0.78);
+  --color-text: #f5f7ff;
+  --color-muted: #b3b9cc;
+  --color-accent: #7ea1ff;
+  --color-border: rgba(132, 150, 214, 0.2);
+  --shadow-soft: 0 25px 50px rgba(4, 9, 24, 0.6);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  font-family: var(--font-base);
+  color: var(--color-text);
+  background: var(--color-bg);
+  line-height: 1.6;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  text-decoration: underline;
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+.container {
+  width: min(960px, 92vw);
+  margin: 0 auto;
+}
+
+.site-header {
+  position: relative;
+  overflow: hidden;
+  padding: 3.5rem 0 4.5rem;
+  background: radial-gradient(circle at top right, rgba(58, 108, 255, 0.24), transparent 55%),
+    linear-gradient(165deg, rgba(153, 171, 255, 0.4), transparent 60%);
+}
+
+nav.top-nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 2.5rem;
+  gap: 1rem;
+}
+
+.brand {
+  font-family: var(--font-accent);
+  font-size: 1.8rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+nav ul {
+  display: flex;
+  list-style: none;
+  gap: 1.5rem;
+  padding: 0;
+  margin: 0;
+}
+
+nav a {
+  font-size: 0.95rem;
+  font-weight: 500;
+}
+
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 50%;
+  border: 1px solid var(--color-border);
+  background: var(--color-bg-soft);
+  box-shadow: 0 10px 25px rgba(18, 26, 53, 0.12);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.theme-toggle:hover,
+.theme-toggle:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 30px rgba(18, 26, 53, 0.14);
+}
+
+.theme-toggle svg {
+  width: 1.3rem;
+  height: 1.3rem;
+  fill: currentColor;
+}
+
+.hero {
+  display: grid;
+  gap: 3rem;
+  align-items: center;
+}
+
+.hero-intro {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.hero-eyebrow {
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--color-muted);
+}
+
+.hero h1 {
+  font-family: var(--font-accent);
+  font-size: clamp(2.6rem, 5vw, 3.8rem);
+  line-height: 1.1;
+  margin: 0;
+}
+
+.lead {
+  font-size: 1.05rem;
+  max-width: 32rem;
+  color: var(--color-muted);
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1.6rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  font-weight: 600;
+  background: var(--color-accent);
+  color: #fff;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 15px 30px rgba(58, 108, 255, 0.35);
+}
+
+.button:hover,
+.button:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 36px rgba(58, 108, 255, 0.35);
+}
+
+.button.ghost {
+  background: transparent;
+  border-color: var(--color-border);
+  color: var(--color-text);
+  box-shadow: none;
+}
+
+.button.ghost:hover,
+.button.ghost:focus-visible {
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+  transform: none;
+}
+
+.hero-card {
+  position: relative;
+  padding: 2.5rem;
+  border-radius: 1.8rem;
+  background: var(--color-bg-soft);
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-soft);
+  backdrop-filter: blur(18px);
+}
+
+.hero-card h2 {
+  margin: 0 0 0.6rem;
+  font-size: 1.4rem;
+}
+
+.hero-card p {
+  margin: 0 0 1.2rem;
+  color: var(--color-muted);
+}
+
+.section {
+  padding: 4.5rem 0;
+}
+
+.section-header {
+  display: grid;
+  gap: 0.5rem;
+  margin-bottom: 2.5rem;
+}
+
+.section-header span {
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.25em;
+  color: var(--color-muted);
+}
+
+.section-header h2 {
+  margin: 0;
+  font-size: clamp(1.8rem, 4vw, 2.4rem);
+  font-family: var(--font-accent);
+}
+
+.about-content {
+  display: grid;
+  gap: 2rem;
+}
+
+.about-grid {
+  display: grid;
+  gap: 1.2rem;
+}
+
+.about-card {
+  padding: 1.8rem;
+  border-radius: 1.4rem;
+  background: var(--color-bg-soft);
+  border: 1px solid var(--color-border);
+  box-shadow: 0 18px 40px rgba(15, 22, 45, 0.08);
+  backdrop-filter: blur(14px);
+}
+
+.about-card h3 {
+  margin-top: 0;
+  margin-bottom: 0.6rem;
+  font-size: 1.2rem;
+}
+
+.about-card p {
+  margin: 0;
+  color: var(--color-muted);
+}
+
+.moments-list {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.moment {
+  padding: 1.6rem;
+  border-radius: 1.4rem;
+  border: 1px solid var(--color-border);
+  background: var(--color-bg-soft);
+  backdrop-filter: blur(12px);
+}
+
+.moment h3 {
+  margin: 0 0 0.4rem;
+  font-size: 1.15rem;
+}
+
+.moment time {
+  font-size: 0.9rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+}
+
+.contact-card {
+  padding: 2rem;
+  border-radius: 1.6rem;
+  border: 1px solid var(--color-border);
+  background: var(--color-bg-soft);
+  backdrop-filter: blur(16px);
+  display: grid;
+  gap: 0.8rem;
+  max-width: 32rem;
+}
+
+.contact-card a {
+  font-weight: 600;
+  color: var(--color-accent);
+}
+
+footer {
+  padding: 3rem 0 2.5rem;
+  background: rgba(17, 21, 36, 0.04);
+}
+
+.footer-inner {
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+  text-align: center;
+  color: var(--color-muted);
+  font-size: 0.9rem;
+}
+
+.footer-links {
+  display: flex;
+  justify-content: center;
+  gap: 1.5rem;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+@media (min-width: 720px) {
+  .hero {
+    grid-template-columns: 1.1fr 0.9fr;
+    gap: 4rem;
+  }
+
+  .about-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .moments-list {
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  .footer-inner {
+    flex-direction: row;
+    justify-content: space-between;
+    text-align: left;
+  }
+}
+
+@media (max-width: 640px) {
+  nav.top-nav {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  nav ul {
+    width: 100%;
+    flex-wrap: wrap;
+    justify-content: flex-start;
+  }
+
+  .hero {
+    text-align: left;
+  }
+
+  .hero-actions {
+    justify-content: flex-start;
+  }
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,0 +1,44 @@
+(function () {
+  const root = document.documentElement;
+  const storedTheme = window.localStorage.getItem('adrian-theme');
+  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
+  const toggleButton = document.getElementById('theme-toggle');
+  const yearSpan = document.getElementById('year');
+
+  function setTheme(mode) {
+    if (mode === 'dark') {
+      root.setAttribute('data-theme', 'dark');
+    } else if (mode === 'light') {
+      root.setAttribute('data-theme', 'light');
+    } else {
+      root.setAttribute('data-theme', prefersDark.matches ? 'dark' : 'light');
+    }
+  }
+
+  function cycleTheme() {
+    const current = root.getAttribute('data-theme');
+    const next = current === 'dark' ? 'light' : 'dark';
+    setTheme(next);
+    window.localStorage.setItem('adrian-theme', next);
+  }
+
+  if (storedTheme === 'light' || storedTheme === 'dark') {
+    setTheme(storedTheme);
+  } else {
+    setTheme('auto');
+  }
+
+  prefersDark.addEventListener('change', () => {
+    if (!window.localStorage.getItem('adrian-theme')) {
+      setTheme('auto');
+    }
+  });
+
+  if (toggleButton) {
+    toggleButton.addEventListener('click', cycleTheme);
+  }
+
+  if (yearSpan) {
+    yearSpan.textContent = new Date().getFullYear().toString();
+  }
+})();

--- a/datenschutz.html
+++ b/datenschutz.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<html lang="de" data-theme="auto">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Datenschutzhinweise für die private Landingpage von Adrian Dylan Wulf." />
+    <title>Datenschutz – Adrian Dylan Wulf</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Manrope:wght@300;400;600;700&family=Playfair+Display:wght@500;600&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/css/styles.css" />
+  </head>
+  <body>
+    <header class="site-header" id="top">
+      <div class="container">
+        <nav class="top-nav" aria-label="Hauptnavigation">
+          <a class="brand" href="index.html">Adrian</a>
+          <ul>
+            <li><a href="index.html#about">Über mich</a></li>
+            <li><a href="index.html#moments">Momente</a></li>
+            <li><a href="index.html#contact">Kontakt</a></li>
+          </ul>
+          <button class="theme-toggle" id="theme-toggle" type="button" aria-label="Darstellung wechseln">
+            <span class="sr-only">Design wechseln</span>
+            <svg class="icon-sun" viewBox="0 0 24 24" aria-hidden="true">
+              <path
+                d="M12 4.5V2m0 20v-2.5m7.5-7.5H22M2 12h2.5m14.1-5.6 1.8-1.8M4.6 19.4l1.8-1.8m0-9.2L4.6 6.4m14.8 14.8-1.8-1.8M12 7.5a4.5 4.5 0 1 1 0 9 4.5 4.5 0 0 1 0-9Z"
+              />
+            </svg>
+            <svg class="icon-moon" viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M21 14.5A9 9 0 0 1 9.5 3 7.5 7.5 0 1 0 21 14.5Z" />
+            </svg>
+          </button>
+        </nav>
+
+        <div class="hero">
+          <div class="hero-intro">
+            <p class="hero-eyebrow">Sicherheit &amp; Vertrauen</p>
+            <h1>Datenschutzerklärung</h1>
+            <p class="lead">Hier findest du die wenigen Hinweise, die für diesen privaten Ort im Netz wichtig sind.</p>
+          </div>
+          <aside class="hero-card">
+            <h2>Kurz gesagt</h2>
+            <p>Es gibt kein Tracking, keine Werbung und keine Formulare. Nur eine E-Mail-Adresse zum Kontakt.</p>
+          </aside>
+        </div>
+      </div>
+    </header>
+
+    <main>
+      <section class="section">
+        <div class="container about-content">
+          <article class="about-card">
+            <h3>1. Verantwortlich</h3>
+            <p>
+              Adrian Dylan Wulf<br />
+              E-Mail: <a href="mailto:anfrage@adriandylanwulf.de">anfrage@adriandylanwulf.de</a>
+            </p>
+          </article>
+          <article class="about-card">
+            <h3>2. Zweck dieser Seite</h3>
+            <p>
+              Diese Webseite ist eine rein private Landingpage. Sie dient dazu, ein paar persönliche Eindrücke zu teilen und eine
+              Kontaktmöglichkeit bereitzustellen.
+            </p>
+          </article>
+          <article class="about-card">
+            <h3>3. Server-Logfiles</h3>
+            <p>
+              Beim Aufruf der Seite können technisch notwendige Logdaten (z. B. IP-Adresse, Browsertyp, Zeitpunkt) beim Hosting
+              Provider entstehen. Sie werden automatisch gelöscht und dienen allein der Stabilität.
+            </p>
+          </article>
+          <article class="about-card">
+            <h3>4. Kontaktaufnahme</h3>
+            <p>
+              Wenn du eine E-Mail sendest, nutze ich deine Angaben ausschließlich zur Beantwortung und lösche sie anschließend.
+              Eine Weitergabe an Dritte findet nicht statt.
+            </p>
+          </article>
+          <article class="about-card">
+            <h3>5. Local Storage</h3>
+            <p>
+              Für die optionale Hell-/Dunkel-Darstellung speichert dein Browser eine kleine Einstellung im Local Storage. Du kannst
+              sie jederzeit selbst entfernen.
+            </p>
+          </article>
+          <article class="about-card">
+            <h3>6. Deine Rechte</h3>
+            <p>
+              Du kannst jederzeit Auskunft, Berichtigung oder Löschung deiner gespeicherten Daten verlangen. Schreib dazu einfach
+              eine E-Mail an mich.
+            </p>
+          </article>
+          <article class="about-card">
+            <h3>7. Änderungen</h3>
+            <p>Bei Anpassungen der Seite aktualisiere ich diese Hinweise. Stand: April 2025.</p>
+          </article>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <div class="container footer-inner">
+        <span>© <span id="year"></span> Adrian Dylan Wulf</span>
+        <div class="footer-links">
+          <a href="#top">Nach oben</a>
+          <a href="index.html">Zur Startseite</a>
+          <a href="impressum.html">Impressum</a>
+        </div>
+      </div>
+    </footer>
+
+    <script src="assets/js/main.js" defer></script>
+  </body>
+</html>

--- a/impressum.html
+++ b/impressum.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html lang="de" data-theme="auto">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Impressum der privaten Landingpage von Adrian Dylan Wulf." />
+    <title>Impressum – Adrian Dylan Wulf</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Manrope:wght@300;400;600;700&family=Playfair+Display:wght@500;600&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/css/styles.css" />
+  </head>
+  <body>
+    <header class="site-header" id="top">
+      <div class="container">
+        <nav class="top-nav" aria-label="Hauptnavigation">
+          <a class="brand" href="index.html">Adrian</a>
+          <ul>
+            <li><a href="index.html#about">Über mich</a></li>
+            <li><a href="index.html#moments">Momente</a></li>
+            <li><a href="index.html#contact">Kontakt</a></li>
+          </ul>
+          <button class="theme-toggle" id="theme-toggle" type="button" aria-label="Darstellung wechseln">
+            <span class="sr-only">Design wechseln</span>
+            <svg class="icon-sun" viewBox="0 0 24 24" aria-hidden="true">
+              <path
+                d="M12 4.5V2m0 20v-2.5m7.5-7.5H22M2 12h2.5m14.1-5.6 1.8-1.8M4.6 19.4l1.8-1.8m0-9.2L4.6 6.4m14.8 14.8-1.8-1.8M12 7.5a4.5 4.5 0 1 1 0 9 4.5 4.5 0 0 1 0-9Z"
+              />
+            </svg>
+            <svg class="icon-moon" viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M21 14.5A9 9 0 0 1 9.5 3 7.5 7.5 0 1 0 21 14.5Z" />
+            </svg>
+          </button>
+        </nav>
+
+        <div class="hero">
+          <div class="hero-intro">
+            <p class="hero-eyebrow">Rechtliches</p>
+            <h1>Impressum</h1>
+            <p class="lead">Alle gesetzlich erforderlichen Angaben zu dieser privaten Seite auf einen Blick.</p>
+          </div>
+          <aside class="hero-card">
+            <h2>Private Landingpage</h2>
+            <p>Diese Seite verfolgt keine wirtschaftlichen Zwecke. Sie ist ein persönliches Projekt von Adrian.</p>
+          </aside>
+        </div>
+      </div>
+    </header>
+
+    <main>
+      <section class="section">
+        <div class="container about-content">
+          <article class="about-card">
+            <h3>Angaben gemäß § 5 TMG</h3>
+            <p>
+              Adrian Dylan Wulf<br />
+              Hamburg, Deutschland<br />
+              Kontakt: <a href="mailto:anfrage@adriandylanwulf.de">anfrage@adriandylanwulf.de</a>
+            </p>
+          </article>
+          <article class="about-card">
+            <h3>Verantwortlich für den Inhalt</h3>
+            <p>Adrian Dylan Wulf (Anschrift wie oben).</p>
+          </article>
+          <article class="about-card">
+            <h3>Urheberrecht</h3>
+            <p>
+              Die Inhalte dieser Webseite sind urheberrechtlich geschützt. Eine Nutzung oder Vervielfältigung ist nur nach
+              vorheriger Absprache möglich.
+            </p>
+          </article>
+          <article class="about-card">
+            <h3>Haftung für Inhalte</h3>
+            <p>
+              Die Inhalte dieser Seite wurden mit größter Sorgfalt erstellt. Für die Richtigkeit, Vollständigkeit und
+              Aktualität übernehme ich dennoch keine Gewähr.
+            </p>
+          </article>
+          <article class="about-card">
+            <h3>Haftung für Links</h3>
+            <p>
+              Diese private Seite enthält nur selten Links zu externen Webseiten. Für deren Inhalte sind ausschließlich die
+              jeweiligen Betreiber verantwortlich.
+            </p>
+          </article>
+          <article class="about-card">
+            <h3>Streitschlichtung</h3>
+            <p>
+              Ich nehme nicht an Streitbeilegungsverfahren vor einer Verbraucherschlichtungsstelle teil. Als private Seite besteht
+              keine Verpflichtung dazu.
+            </p>
+          </article>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <div class="container footer-inner">
+        <span>© <span id="year"></span> Adrian Dylan Wulf</span>
+        <div class="footer-links">
+          <a href="#top">Nach oben</a>
+          <a href="index.html">Zur Startseite</a>
+          <a href="datenschutz.html">Datenschutz</a>
+        </div>
+      </div>
+    </footer>
+
+    <script src="assets/js/main.js" defer></script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,178 @@
+<!DOCTYPE html>
+<html lang="de" data-theme="auto">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Private Landingpage von Adrian Dylan Wulf: ein digitaler Rückzugsort mit persönlichen Notizen, Momenten und Kontakt."
+    />
+    <title>Adrian Dylan Wulf – Mein Platz im Netz</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Manrope:wght@300;400;600;700&family=Playfair+Display:wght@500;600&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/css/styles.css" />
+  </head>
+  <body>
+    <header class="site-header" id="top">
+      <div class="container">
+        <nav class="top-nav" aria-label="Hauptnavigation">
+          <a class="brand" href="#top">Adrian</a>
+          <ul>
+            <li><a href="#about">Über mich</a></li>
+            <li><a href="#moments">Momente</a></li>
+            <li><a href="#contact">Kontakt</a></li>
+          </ul>
+          <button class="theme-toggle" id="theme-toggle" type="button" aria-label="Darstellung wechseln">
+            <span class="sr-only">Design wechseln</span>
+            <svg class="icon-sun" viewBox="0 0 24 24" aria-hidden="true">
+              <path
+                d="M12 4.5V2m0 20v-2.5m7.5-7.5H22M2 12h2.5m14.1-5.6 1.8-1.8M4.6 19.4l1.8-1.8m0-9.2L4.6 6.4m14.8 14.8-1.8-1.8M12 7.5a4.5 4.5 0 1 1 0 9 4.5 4.5 0 0 1 0-9Z"
+              />
+            </svg>
+            <svg class="icon-moon" viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M21 14.5A9 9 0 0 1 9.5 3 7.5 7.5 0 1 0 21 14.5Z" />
+            </svg>
+          </button>
+        </nav>
+
+        <div class="hero">
+          <div class="hero-intro">
+            <p class="hero-eyebrow">Moin, ich bin Adrian</p>
+            <h1>Adrian Dylan Wulf</h1>
+            <p class="lead">
+              Willkommen auf meiner kleinen Landingpage. Hier sammele ich ruhige Gedanken, Lieblingsmomente und Wege, wie du
+              mich erreichen kannst. Ohne Buzzwords – nur ein ehrlicher Einblick in das, was mich gerade bewegt.
+            </p>
+            <div class="hero-actions">
+              <a class="button" href="#about">Mehr erfahren</a>
+              <a class="button ghost" href="mailto:anfrage@adriandylanwulf.de">E-Mail schreiben</a>
+            </div>
+          </div>
+          <aside class="hero-card" aria-label="Aktuelle Lieblingssachen">
+            <h2>Gerade auf meiner Liste</h2>
+            <p>
+              Ein analoges Fotoalbum vom letzten Roadtrip, ein unveröffentlichter Mixtape-Entwurf und ein Stapel Notizbücher für
+              neue Geschichten.
+            </p>
+            <p><strong>Playlist:</strong> „Nordlichter bei Nacht“ – perfekte Begleitung für Fokus-Zeiten.</p>
+          </aside>
+        </div>
+      </div>
+    </header>
+
+    <main>
+      <section id="about" class="section">
+        <div class="container about-content">
+          <div class="section-header">
+            <span>Über mich</span>
+            <h2>Ein digitaler Rückzugsort</h2>
+            <p>
+              Ich heiße Adrian Dylan Wulf, bin ein 90er-Kid mit Liebe zu Musik, Web und echten Gesprächen. Diese Seite ist kein
+              Portfolio, sondern mein persönliches Wohnzimmer im Netz.
+            </p>
+          </div>
+          <div class="about-grid">
+            <article class="about-card">
+              <h3>Was mich antreibt</h3>
+              <p>
+                Ruhe, klare Gedanken und das Spiel mit Klangfarben. Ich dokumentiere spontane Ideen, sammle Field-Recordings und
+                halte Erinnerungen fest, bevor sie davonfliegen.
+              </p>
+            </article>
+            <article class="about-card">
+              <h3>Woran ich arbeite</h3>
+              <p>
+                Momentan schreibe ich an einem kleinen Newsletter, kuratiere Mixtapes für Freund:innen und bastle an einer
+                Mini-App für persönliche Routinen.
+              </p>
+            </article>
+            <article class="about-card">
+              <h3>Wie ich auftanke</h3>
+              <p>
+                Lange Spaziergänge entlang der Elbe, gute Kaffees und das Durchblättern alter Fotoarchive. Offline-Momente geben
+                mir Energie für neue Ideen.
+              </p>
+            </article>
+            <article class="about-card">
+              <h3>Was du hier findest</h3>
+              <p>
+                Kleine Updates, ein paar Lieblingslinks und eine offene Einladung, einfach mal Hallo zu sagen. Mehr braucht es
+                für diesen Ort nicht.
+              </p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section id="moments" class="section">
+        <div class="container">
+          <div class="section-header">
+            <span>Momente</span>
+            <h2>Kurze Notizen aus meinem Alltag</h2>
+            <p>Statt langer Stories nur drei Momentaufnahmen, die mich gerade begleiten.</p>
+          </div>
+          <div class="moments-list">
+            <article class="moment">
+              <time datetime="2025-03">März 2025</time>
+              <h3>Kleine Wohnzimmer-Session</h3>
+              <p>
+                Zwei Freund:innen, ein Mikrofon und eine lose Songidee. Wir haben alles live eingespielt und ich höre den Mix
+                noch immer gern zum Abschalten.
+              </p>
+            </article>
+            <article class="moment">
+              <time datetime="2025-02">Februar 2025</time>
+              <h3>Skizzenbuch-Ritual</h3>
+              <p>
+                Jeden Morgen drei Seiten schreiben, ohne zurückzublicken. Es hilft, den Kopf frei zu bekommen und neue Themen zu
+                entdecken.
+              </p>
+            </article>
+            <article class="moment">
+              <time datetime="2025-01">Januar 2025</time>
+              <h3>Winterlichter in Hamburg</h3>
+              <p>
+                Ein abendlicher Spaziergang durch St. Pauli mit Kamera und heißem Kakao. Die Lichter reflektieren im Regen –
+                genau mein Ding.
+              </p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section id="contact" class="section">
+        <div class="container">
+          <div class="section-header">
+            <span>Kontakt</span>
+            <h2>Sag gerne Hallo</h2>
+            <p>Du hast Fragen, möchtest Musik tauschen oder einfach plaudern? Ich freue mich von dir zu hören.</p>
+          </div>
+          <div class="contact-card">
+            <p><strong>E-Mail:</strong></p>
+            <a href="mailto:anfrage@adriandylanwulf.de">anfrage@adriandylanwulf.de</a>
+            <p>
+              Am liebsten erreichst du mich per Mail. Manchmal antworte ich nicht sofort – das liegt daran, dass ich bewusst Zeit
+              offline verbringe.
+            </p>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <div class="container footer-inner">
+        <span>© <span id="year"></span> Adrian Dylan Wulf</span>
+        <div class="footer-links">
+          <a href="impressum.html">Impressum</a>
+          <a href="datenschutz.html">Datenschutz</a>
+        </div>
+      </div>
+    </footer>
+
+    <script src="assets/js/main.js" defer></script>
+  </body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://adriandylanwulf.de/</loc>
+    <lastmod>2025-04-05</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://adriandylanwulf.de/impressum.html</loc>
+    <lastmod>2025-04-05</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+  <url>
+    <loc>https://adriandylanwulf.de/datenschutz.html</loc>
+    <lastmod>2025-04-05</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- rebuild the homepage as a focused personal landing page with intro, moments and contact sections
- refresh shared styles and script to support the lighter layout and dual theme toggle
- align legal pages, README and sitemap with the simplified personal focus

## Testing
- No automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e1b63a66b083258009af249121fca0